### PR TITLE
Added Memmap, Scatter Reads

### DIFF
--- a/DMALib/entry.cpp
+++ b/DMALib/entry.cpp
@@ -34,10 +34,27 @@ int main()
 	//read again
 	res = target.read<uint64_t>(target.getBaseAddress() + 0x3038);
 
+	//Create a handle for scatter
+	auto handle = target.createScatterHandle();
+
+	//When doing scatter reads you can NOT read a pointer and have the next request use that pointer.
+	//The pointer that you add to a scatter request has to be first executed before you can use any of the "Scattered" data.
+	uint64_t res2;
+	target.addScatterReadRequest(handle, target.getBaseAddress() + 0x3038, &res, sizeof(res));
+	target.addScatterReadRequest(handle, target.getBaseAddress() + 0x3040, &res2, sizeof(res2));
+	target.executeReadScatter(handle);
+
+	printf("Read Scatter result: %llu\n", res);
+	printf("Read Scatter result2: %llu\n", res2);
+
+	
+	//Always make sure you close your handle
+	target.closeScatterHandle(handle);
+
 	//print the result
 	printf("result: %llu\n", res);
 
 	getchar();
-	DMAHandler::closeDMA();
+	target.closeDMA();
 	return 0;
 }

--- a/DMALib/libs/leechcore.h
+++ b/DMALib/libs/leechcore.h
@@ -1,155 +1,22 @@
-// leechcore.h : header file for the leechcore module - which purpose is to
-// expose low-level device physical memory functionality.
+// leechcore.h : external header of the LeechCore library.
 //
-// This library is thread-safe in all functions with the notable exceptions  of
-// the LeechCore_Open() and LeechCore_Close() functions. Some devices may allow
-// multi-threaded access while in reality most devices are single-threaded  and
-// will control synchronization where necessary with locks.
+// LeechCore is a library which abstracts away reading and writing to various
+// software and hardware acquisition sources. Sources ranges from memory dump
+// files to driver backed live memory to hardware (FPGA) DMA backed memory.
 //
-// The library is initialized by calling LeechCore_Open with a LEECHCORE_CONFIG
-// struct containing the correct configuration paramters. Note that the version
-// and magic values must be set in addition to the szDevice configuration value
-// Also, it may be possible to optionally connect to a remote leechcore service
-// or instance over RPC by specifying a szRemote configuration value.
+// LeechCore built-in device support may be extended with external plugin
+// device drivers placed as .dll or .so files in the same folder as LeechCore.
 //
-// ----------------------------------------------------------------------------
+// For more information please consult the LeechCore information on Github:
+// - README: https://github.com/ufrisk/LeechCore
+// - GUIDE:  https://github.com/ufrisk/LeechCore/wiki
 //
-// Remote instance: szRemote configuration value. Connect to a remote leechcore
-// instance by specifying a configuration value in the szRemote parameter. If a
-// loaded already valid instance exists remotely this will be prioritized above
-// the value in szDevice.    If the acquisition device is not yet loaded by the
-// remote instance the value in szDevice will be used. Normally, the connection
-// will take place as a mutually authenticated encrypted connection secured  by
-// kerberos. If not possible or desirable the 'insecure' value may be specified
-// to disable authentication and security.
-// Syntax:
-//    rpc://<remote_spn>:<host>[:<options>] (remote_spn = kerberos SPN of     )
-//                                          (remote service or 'insecure'     )
-//
-// Valid options:                           (optional comma-separated list    )
-//    port=<port>                           (RPC TCP port of the remote system)
-//    nocompress                            (disable transport compression    )
-//    
-// Examples:
-//    rpc://insecure:remotehost.example.com (connect insecure to remote host  )
-//    rpc://user@ad.domain.com:192.0.0.5    (connect   secure to remote host  )
-//    rpc://insecure:127.0.0.0:6666         (connect insecure non-default port)
-//
-// The remote connector may also connect to pipe handles provided in the config
-// string. This is only used internally by the LeechAgent for communication for
-// parent/child process and may not be used by external applications. Syntax is
-// pipe://<handle_id_input>:<handle_id_output>.
-//
-// ----------------------------------------------------------------------------
-//
-// Device to connect to: szDevice contains the device to capture memory from.
-// Supported memory acquisition devices are:
-// USB3380 : hardware, read/write, 32-bit (4GB) addressing only. Requires a
-//           PCILeech flashed USB3380 device connected over USB and Google
-//           Android WinUSB drivers to be installed. Download and install from:
-//           http://developer.android.com/sdk/win-usb.html#download
-//           Syntax:
-//             USB3380
-//             USB3380://USB2                     (force USB2 connection speed)
-//
-// FPGA :    hardware, read/write - requires a PCILeech FPGA flashed hardware
-//           device as shown at: https://github.com/ufrisk/pcileech-fpga
-//           Also requires the FTD3XX.DLL from ftdichip to be placed in the
-//           same directory as the executable. Download from ftdichip at:
-//           https://www.ftdichip.com/Drivers/D3XX/FTD3XXLibrary_v1.3.0.2.zip
-//           Syntax:
-//             FGPA
-//             FPGA://<comma_separated_options_list>
-//           Example: FPGA://pciegen=1,deviceindex=1
-//           Options:
-//             pciegen=     PCIe generation to use, 1 or 2
-//             tmread=      Read delay in uS
-//             tmwrite=     Write delay in uS
-//             tmprobe=     Probe delay in uS
-//             algo=        1 (normal) or 2 (tiny)
-//             readsize=    max chunk read size in bytes
-//             readretry=   number of retries on fail
-//             deviceindex= device index to open
-//
-// RAWUDP :  hardware, read/write - connect to a remote FPGA over the network
-//           using a rudimentary UDP implmentation of the FPGA USB protocol.
-//           Supported devices: NeTV2 - https://github.com/ufrisk/pcileech-fpga
-//           Syntax:
-//             RAWUDP://<comma_separated_options_list>
-//           Example: RAWUDP://ip=192.168.0.222
-//           Options:
-//             ip= ip address or host name to connect to.
-//           (options for fpga device type also applies).
-//
-// SP605TCP : hardware, read/write - connect to a remote SP605 FPGA over the
-//           network using the implementation created by @d_olex.
-//           https://github.com/Cr4sh/s6_pcie_microblaze
-//           Syntax:
-//             SP605TCP://<target_ip>[:<target_port>]        (port is optional)
-//
-// RAWTCP :  read/write - connect to a remote raw tcp device - such as HPE iLO
-//           that have been patched to support DMA as per blog entry below:
-//           https://www.synacktiv.com/posts/exploit/using-your-bmc-as-a-dma-device-plugging-pcileech-to-hpe-ilo-4.html
-//           Syntax:
-//             RAWTCP://<target_ip>[:<target_port>]          (port is optional)
-//
-// HvSavedState : read-only - connect to a Hyper-V saved state file. In order
-//           to do so the .dll file 'vmsavedstatedumpprovider.dll' must be
-//           placed in same directory as the executable file.
-//
-// PMEM :    load the rekall winpmem driver into the kernel and connect to it
-//           to acquire memory. The signed driver `.sys` file may be found at:
-//           https://github.com/Velocidex/c-aff4/tree/master/tools/pmem/resources/winpmem
-//           Download the driver file `att_winpmem_64.sys` and copy it to the
-//           directory of leechcore.dll and run executable as elevated admin
-//           using syntax below:
-//           Syntax:
-//             PMEM              (use att_winpmem_64.sys in directory of executable)
-//             PMEM://<non_default_path_to_file_winpmem_64.sys>
-//
-// TOTALMELTDOWN : read/write - requires a Windows 7 system vulnerable to the
-//           "Total Meltdown" vulnerability - CVE-2018-1038.
-//           Syntax:
-//             TOTALMELTDOWN
-//
-// FILE :    use dump file of any of the below listed formats:
-//             - raw linear memory dump.
-//             - full microsoft crash dump (DumpIt).
-//             - full elf core dump (VirtualBox).
-//             - VMware save/dump file (.vmem + .vmss/.vmsn).
-//           The format to use is auto-detected.
-//           Syntax:
-//             <filename>        (no device-type prefix - just use the file name)
-//             FILE://<filename>
-//
-// DumpIt :  DumpIt is a "virtual" device. It's only possible to use the DumpIt
-//           device if the main process containing LeechCore has been started
-//           with DumpIt in LiveKD mode.
-//           Example 1:
-//             DumpIt.exe /LIVEKD /A MemProcFS.exe
-//           Example 2:
-//             DumpIt.exe /LIVEKD /A LeechSvc.exe /C "interactive insecure"
-//             and then connect to remote service by:
-//             MemProcFS.exe -remote rpc://insecure:192.168.x.x -device DumpIt
-//
-// EXISTING : Attach to existing already loaded configuration. This is done
-//           instead of the default behaviour of closing any existing devices
-//           and initializing the new requested device. If no existing device
-//           exists the call to LeechCore_Open will fail.
-//           Syntax:
-//             EXISTING
-//
-// EXISTINGREMOTE : Same as EXISTING but applying the EXISTING device on the
-//           remote system. Use only in conjunction with a remote system.
-//           Syntax:
-//             EXISTINGREMOTE
-//
-//
-// (c) Ulf Frisk, 2018-2020
+// (c) Ulf Frisk, 2020-2023
 // Author: Ulf Frisk, pcileech@frizk.net
 //
-// Header Version: 1.7
+// Header Version: 2.16.1
 //
+
 #ifndef __LEECHCORE_H__
 #define __LEECHCORE_H__
 #ifdef __cplusplus
@@ -157,436 +24,590 @@ extern "C" {
 #endif /* __cplusplus */
 
 //-----------------------------------------------------------------------------
-// WINDOWS / LINUX COMPATIBILITY BELOW:
+// OS COMPATIBILITY BELOW:
 //-----------------------------------------------------------------------------
 
 #ifdef _WIN32
+
 #include <Windows.h>
+#define EXPORTED_FUNCTION                   __declspec(dllexport)
 typedef unsigned __int64                    QWORD, *PQWORD;
-#define DLLEXPORT                           __declspec(dllexport)
-#ifdef _WIN64
-#define ARCH_64
-#endif /* _WIN64 */
+
 #endif /* _WIN32 */
 #ifdef LINUX
-#define ARCH_X64
-#include <stdint.h>
-#include <stddef.h>
-typedef void                                VOID, *PVOID, *LPVOID;
-typedef void                                *HANDLE, **PHANDLE;
-typedef uint32_t                            BOOL, *PBOOL;
-typedef uint8_t                             BYTE, *PBYTE;
-typedef char                                CHAR, *PCHAR, *PSTR, *LPSTR;
-typedef const CHAR                          *LPCSTR;
-typedef uint16_t                            WORD, *PWORD, USHORT, *PUSHORT;
-typedef uint32_t                            DWORD, *PDWORD;
+
+#include <inttypes.h>
+#include <stdlib.h>
+#define EXPORTED_FUNCTION                   __attribute__((visibility("default")))
+typedef void                                VOID, *PVOID, *HANDLE, **PHANDLE, *HMODULE;
 typedef long long unsigned int              QWORD, *PQWORD, ULONG64, *PULONG64;
+typedef size_t                              SIZE_T, *PSIZE_T;
+typedef uint64_t                            FILETIME, *PFILETIME;
+typedef uint32_t                            DWORD, *PDWORD, *LPDWORD, BOOL, *PBOOL, NTSTATUS;
+typedef uint16_t                            WORD, *PWORD;
+typedef uint8_t                             BYTE, *PBYTE, *LPBYTE, UCHAR;
+typedef char                                CHAR, *PCHAR, *LPSTR, *LPCSTR;
+typedef uint16_t                            WCHAR, *PWCHAR, *LPWSTR, *LPCWSTR;
 #define MAX_PATH                            260
-#define DLLEXPORT                           __attribute__((visibility("default")))
 #define _In_
-#define _Out_
 #define _In_z_
-#define _Inout_
 #define _In_opt_
+#define _In_reads_(x)
+#define _In_reads_bytes_(x)
+#define _In_reads_bytes_opt_(x)
+#define _In_reads_opt_(x)
+#define _Inout_
+#define _Inout_bytecount_(x)
+#define _Inout_opt_
+#define _Inout_updates_opt_(x)
+#define _Out_
 #define _Out_opt_
 #define _Out_writes_(x)
+#define _Out_writes_bytes_opt_(x)
+#define _Out_writes_opt_(x)
+#define _Out_writes_to_(x,y)
+#define _When_(x,y)
+#define _Frees_ptr_opt_
+#define _Post_ptr_invalid_
 #define _Check_return_opt_
 #define _Printf_format_string_
-#define _Inout_updates_bytes_(x)
-#define _In_reads_(cbDataIn)
-#define _Out_writes_opt_(x)
-#define _Success_(return)
-#define _Frees_ptr_opt_
+#define _Success_(x)
+
 #endif /* LINUX */
 
-//-----------------------------------------------------------------------------
-// GENERAL HEADER DEFINES BELOW:
-//-----------------------------------------------------------------------------
 
-#define MEM_IO_SCATTER_HEADER_MAGIC                     0xffff6548
-#define MEM_IO_SCATTER_HEADER_VERSION                   0x0003
-
-#ifdef ARCH_64
-typedef struct tdMEM_IO_SCATTER_HEADER {
-    DWORD magic;            // magic
-    WORD version;           // version
-    WORD Future1;
-    ULONG64 qwA;            // base address.
-    DWORD cbMax;            // bytes to read (DWORD boundry, max 0x1000); pb must have room for this.
-    DWORD cb;               // bytes read into result buffer.
-    PBYTE pb;               // ptr to 0x1000 sized buffer to receive read bytes.
-    PVOID pvReserved1;      // reserved for use by caller.
-    PVOID pvReserved2;      // reserved for use by caller.
-    PVOID Future2[8];
-} MEM_IO_SCATTER_HEADER, *PMEM_IO_SCATTER_HEADER, **PPMEM_IO_SCATTER_HEADER;
-#endif /* ARCH_64 */
-
-#ifndef ARCH_64
-typedef struct tdMEM_IO_SCATTER_HEADER {
-    DWORD magic;            // magic
-    WORD version;           // version
-    WORD Future1;
-    ULONG64 qwA;            // base address.
-    DWORD cbMax;            // bytes to read (DWORD boundry, max 0x1000); pb must have room for this.
-    DWORD cb;               // bytes read into result buffer.
-    PBYTE pb;               // ptr to 0x1000 sized buffer to receive read bytes.
-    DWORD dwFiller64_1;
-    PVOID pvReserved1;      // reserved for use by caller.
-    DWORD dwFiller64_2;
-    PVOID pvReserved2;      // reserved for use by caller.
-    DWORD dwFiller64_3;
-    PVOID Future2[8];
-    DWORD dwFiller64_4[8];
-} MEM_IO_SCATTER_HEADER, *PMEM_IO_SCATTER_HEADER, **PPMEM_IO_SCATTER_HEADER;
-#endif /* ARCH_64 */
 
 //-----------------------------------------------------------------------------
-// LEECHCORE INITIALIZATION / CLOSE FUNCTIONALITY BELOW:
+// Create and Close LeechCore devices:
+// It's possible to create multiple LeechCore devices in parallel and also of
+// different types if the underlying device will allow this. LeechCore will
+// automatically take care of and abstract away any hardware/software issues
+// with regards to the underlying devices.
+//
+// For more information about supported devices please check out the LeechCore
+// guide at: https://github.com/ufrisk/LeechCore/wiki
 //-----------------------------------------------------------------------------
 
-typedef enum tdLEECHCORE_DEVICE {
-    LEECHCORE_DEVICE_NA = 0,
-    LEECHCORE_DEVICE_FILE = 1,
-    LEECHCORE_DEVICE_PMEM = 2,
-    LEECHCORE_DEVICE_FPGA = 3,
-    LEECHCORE_DEVICE_SP605_TCP = 4,
-    LEECHCORE_DEVICE_USB3380 = 5,
-    LEECHCORE_DEVICE_TOTALMELTDOWN = 6,
-    LEECHCORE_DEVICE_HVSAVEDSTATE = 7,
-    LEECHCORE_DEVICE_RAWTCP = 8,
-} LEECHCORE_DEVICE;
+#define LC_CONFIG_VERSION                       0xc0fd0002
+#define LC_CONFIG_ERRORINFO_VERSION             0xc0fe0002
 
-#define LEECHCORE_CONFIG_MAGIC                          0xffff6549
-#define LEECHCORE_CONFIG_VERSION                        0x0001
+#define LC_CONFIG_PRINTF_ENABLED                0x01
+#define LC_CONFIG_PRINTF_V                      0x02
+#define LC_CONFIG_PRINTF_VV                     0x04
+#define LC_CONFIG_PRINTF_VVV                    0x08
 
-#define LEECHCORE_CONFIG_FLAG_PRINTF                    0x0001
-#define LEECHCORE_CONFIG_FLAG_PRINTF_VERBOSE_1          0x0002
-#define LEECHCORE_CONFIG_FLAG_PRINTF_VERBOSE_2          0x0004
-#define LEECHCORE_CONFIG_FLAG_PRINTF_VERBOSE_3          0x0008
-#define LEECHCORE_CONFIG_FLAG_REMOTE_NO_COMPRESS        0x0010
+typedef struct LC_CONFIG {
+    // below are set by caller
+    DWORD dwVersion;                        // must equal LC_CREATE_VERSION
+    DWORD dwPrintfVerbosity;                // printf verbosity according to LC_PRINTF_*
+    CHAR szDevice[MAX_PATH];                // device configuration - see wiki for additional info.
+    CHAR szRemote[MAX_PATH];                // remote configuration - see wiki for additional info.
+    _Check_return_opt_ int(*pfn_printf_opt)(_In_z_ _Printf_format_string_ char const *const _Format, ...);
+    // below are set by caller, updated by LeecCore
+    QWORD paMax;                            // max physical address (disables any max address auto-detect).
+    // below are set by LeechCore
+    BOOL fVolatile;
+    BOOL fWritable;
+    BOOL fRemote;
+    BOOL fRemoteDisableCompress;
+    CHAR szDeviceName[MAX_PATH];            // device name - such as 'fpga' or 'file'.
+} LC_CONFIG, *PLC_CONFIG;
 
-typedef struct tdLEECHCORE_CONFIG {
-    DWORD magic;                // set by caller.
-    WORD version;               // set by caller.
-    WORD flags;                 // set by caller, updated by device.
-    ULONG64 paMax;              // set by caller, updated by device.
-    ULONG64 cbMaxValueDummy;    // set by device. (dummy - set to MAX_VALUE [deprecated cbMaxSizeMemIo])
-    ULONG64 paMaxNative;        // set by device.
-    LEECHCORE_DEVICE tpDevice;  // set by device.
-    BOOL fWritable;             // set by device. (is device writable?)
-    BOOL fVolatile;             // set by device. (is device volatile / memory may change?)
-    BOOL fVolatileMaxAddress;   // set by device. (is max address volatile? - poll changes with LEECHCORE_OPT_MEMORYINFO_ADDR_MAX)
-    BOOL fRemote;               // set by device.
-    WORD VersionMajor;          // set by device.
-    WORD VersionMinor;          // set by device.
-    WORD VersionRevision;       // set by device.
-    CHAR szDevice[MAX_PATH];    // set by caller.
-    CHAR szRemote[MAX_PATH];    // set by caller.
-    // optional 'printf' function pointer. if set to non null value 'printf'
-    // calls will be redirected. useful when logging to files.
-    _Check_return_opt_ int(*pfn_printf_opt)(_In_z_ _Printf_format_string_ char const* const _Format, ...);  // set by caller.
-#ifndef ARCH_64
-    DWORD dwFiller64_1;
-#endif /* ARCH_64 */
-} LEECHCORE_CONFIG, *PLEECHCORE_CONFIG;
-
-#ifdef ARCH_64
-typedef struct tdLEECHCORE_PAGESTAT_MINIMAL {
-    HANDLE h;
-    VOID(*pfnPageStatUpdate)(HANDLE h, ULONG64 pa, ULONG64 cPageSuccessAdd, ULONG64 cPageFailAdd);
-} LEECHCORE_PAGESTAT_MINIMAL, *PLEECHCORE_PAGESTAT_MINIMAL;
-#endif /* ARCH_64 */
-
-#ifndef ARCH_64
-typedef struct tdLEECHCORE_PAGESTAT_MINIMAL {
-    HANDLE h;
-    DWORD dwFiller64_1;
-    VOID(*pfnPageStatUpdate)(HANDLE h, ULONG64 pa, ULONG64 cPageSuccessAdd, ULONG64 cPageFailAdd);
-    DWORD dwFiller64_2;
-} LEECHCORE_PAGESTAT_MINIMAL, *PLEECHCORE_PAGESTAT_MINIMAL;
-#endif /* ARCH_64 */
+typedef struct tdLC_CONFIG_ERRORINFO {
+    DWORD dwVersion;                        // must equal LC_CONFIG_ERRORINFO_VERSION
+    DWORD cbStruct;
+    DWORD _FutureUse[16];
+    BOOL fUserInputRequest;
+    DWORD cwszUserText;
+    WCHAR wszUserText[];
+} LC_CONFIG_ERRORINFO, *PLC_CONFIG_ERRORINFO, **PPLC_CONFIG_ERRORINFO;
 
 /*
-* Open a connection to the target device. The LeechCore initialization may fail
-* if the underlying device cannot be opened or if the LeechCore is already
-* initialized. If already initialized please connect with device EXISTING or
-* call LeechCore_Close() before opening a new device.
-* -- pInformation
-* -- result
-*/
-_Success_(return)
-DLLEXPORT BOOL LeechCore_Open(_Inout_ PLEECHCORE_CONFIG pConfig);
-
-/*
-* Clean up various device related stuff and deallocate memory buffers.
-*/
-DLLEXPORT VOID LeechCore_Close();
-
-
-
-//-----------------------------------------------------------------------------
-// LEECHCORE CORE READ AND WRITE FUNCTIONALITY BELOW:
-//-----------------------------------------------------------------------------
-
-#define LEECHCORE_FLAG_READ_RETRY           0x01
-#define LEECHCORE_FLAG_WRITE_RETRY          0x01
-#define LEECHCORE_FLAG_WRITE_VERIFY         0x02
-
-/*
-* Free memory allocated by the LeechCore.
-* -- pvMem
+* Create a new LeechCore device according to the supplied configuration.
+* CALLER LcMemFree: ppLcCreateErrorInfo
+* -- pLcCreateConfig
+* -- ppLcCreateErrorInfo = ptr to receive function allocated struct with error
+*       information upon function failure. This info may contain a user message
+*       requesting user action as an example. Any returned struct should be
+*       free'd by a call to LcMemFree().
 * -- return
 */
-DLLEXPORT VOID LeechCore_MemFree(_Frees_ptr_opt_ PVOID pvMem);
+EXPORTED_FUNCTION _Success_(return != NULL)
+HANDLE LcCreate(
+    _Inout_ PLC_CONFIG pLcCreateConfig
+);
+
+EXPORTED_FUNCTION _Success_(return != NULL)
+HANDLE LcCreateEx(
+    _Inout_ PLC_CONFIG pLcCreateConfig,
+    _Out_opt_ PPLC_CONFIG_ERRORINFO ppLcCreateErrorInfo
+);
 
 /*
-* Allocate a scatter buffer containing empty 0x1000-sized ppMEMs with address
-* set to zero. Caller is responsible for calling LeechCore_MemFree(ppMEMs).
-* CALLER FREE: LeechCore_MemFree(ppMEMs)
+* Close a LeechCore handle and free any resources no longer needed.
+*/
+EXPORTED_FUNCTION
+VOID LcClose(
+    _In_opt_ _Post_ptr_invalid_ HANDLE hLC
+);
+
+
+
+//-----------------------------------------------------------------------------
+// Read and Write memory from underlying device either using contiguous method
+// or more recommended scatter method.
+//
+// The MEM_SCATTER struct allows reading and writing of discontiguous memory
+// chunks which must adhere to the following rules:
+// - maximum size = 0x1000 (4096) bytes = recommended size.
+// - minimum size = 2 DWORDs (8 bytes).
+// - must be DWORD (4 byte) aligned.
+// - must never cross 0x1000 page boundary.
+// - max value of iStack = MEM_SCATTER_STACK_SIZE - 2.
+//-----------------------------------------------------------------------------
+
+#define MEM_SCATTER_VERSION                 0xc0fe0002
+#define MEM_SCATTER_STACK_SIZE              12
+
+typedef struct tdMEM_SCATTER {
+    DWORD version;                          // MEM_SCATTER_VERSION
+    BOOL f;                                 // TRUE = success data in pb, FALSE = fail or not yet read.
+    QWORD qwA;                              // address of memory to read
+    union {
+        PBYTE pb;                           // buffer to hold memory contents
+        QWORD _Filler;
+    };
+    DWORD cb;                               // size of buffer to hold memory contents.
+    DWORD iStack;                           // internal stack pointer
+    QWORD vStack[MEM_SCATTER_STACK_SIZE];   // internal stack
+} MEM_SCATTER, *PMEM_SCATTER, **PPMEM_SCATTER;
+
+#define MEM_SCATTER_ADDR_INVALID            ((QWORD)-1)
+#define MEM_SCATTER_ADDR_ISINVALID(pMEM)    (pMEM->qwA == (QWORD)-1)
+#define MEM_SCATTER_ADDR_ISVALID(pMEM)      (pMEM->qwA != (QWORD)-1)
+#define MEM_SCATTER_STACK_PUSH(pMEM, v)     (pMEM->vStack[pMEM->iStack++] = (QWORD)(v))
+#define MEM_SCATTER_STACK_PEEK(pMEM, i)     (pMEM->vStack[pMEM->iStack - i])
+#define MEM_SCATTER_STACK_SET(pMEM, i, v)   (pMEM->vStack[pMEM->iStack - i] = (QWORD)(v))
+#define MEM_SCATTER_STACK_ADD(pMEM, i, v)   (pMEM->vStack[pMEM->iStack - i] += (QWORD)(v))
+#define MEM_SCATTER_STACK_POP(pMEM)         (pMEM->vStack[--pMEM->iStack])
+
+/*
+* Free LeechCore allocated memory such as memory allocated by the
+* LcAllocScatter / LcCommand functions.
+* -- pv
+*/
+EXPORTED_FUNCTION
+VOID LcMemFree(
+    _Frees_ptr_opt_ PVOID pv
+);
+
+/*
+* Allocate and pre-initialize empty MEMs including a 0x1000 buffer for each
+* pMEM. The result should be freed by LcFree when its no longer needed.
 * -- cMEMs
-* -- pppMEMs = pointer to receive ppMEMs on success.
+* -- pppMEMs = pointer to receive ppMEMs
 * -- return
 */
-_Success_(return)
-DLLEXPORT BOOL LeechCore_AllocScatterEmpty(_In_ DWORD cMEMs, _Out_ PPMEM_IO_SCATTER_HEADER *pppMEMs);
+EXPORTED_FUNCTION _Success_(return)
+BOOL LcAllocScatter1(
+    _In_ DWORD cMEMs,
+    _Out_ PPMEM_SCATTER *pppMEMs
+);
 
 /*
-* Read memory in various non-contigious locations specified by the items in the
-* phDMAs array. Result for each unit of work will be given individually. No upper
-* limit of number of items to read, but no performance boost will be given if
-* above hardware limit. Max size of each unit of work is one 4k page (4096 bytes).
-* -- ppMEMs = array of scatter read headers.
-* -- cpMEMs = count of ppDMAs.
-*/
-DLLEXPORT VOID LeechCore_ReadScatter(_Inout_ PPMEM_IO_SCATTER_HEADER ppMEMs, _In_ DWORD cpMEMs);
-
-/*
-* Try read memory in a fairly optimal way considering device limits. The number
-* of total successfully read bytes is returned. Failed reads will be zeroed out
-* in the returned memory.
-* -- pa
-* -- pb
-* -- cb
-* -- return = the number of bytes successfully read.
-*/
-DLLEXPORT DWORD LeechCore_Read(_In_ ULONG64 pa, _Out_writes_(cb) PBYTE pb, _In_ DWORD cb);
-
-/*
-* Try read memory in a fairly optimal way considering device limits. The number
-* of total successfully read bytes is returned. Failed reads will be zeroed out
-* in the returned memory.
-* -- pa
-* -- pb
-* -- cb
-* -- flags = 0 or LEECHCORE_FLAG_READ_RETRY
-* -- pPageStat = optional minimal statistic struct to update.
-* -- return = the number of bytes successfully read.
-*/
-DLLEXPORT DWORD LeechCore_ReadEx(_In_ ULONG64 pa, _Out_writes_(cb) PBYTE pb, _In_ DWORD cb, _In_ DWORD flags, _In_opt_ PLEECHCORE_PAGESTAT_MINIMAL pPageStat);
-
-/*
-* Write data to the target system if supported by the device.
-* -- pa
-* -- pb
-* -- cb
+* Allocate and pre-initialize empty MEMs excluding the 0x1000 buffer which
+* will be accounted towards the pbData buffer in a contiguous way.
+* The result should be freed by LcFree when its no longer needed.
+* -- cbData = size of pbData (must be cMEMs * 0x1000)
+* -- pbData = buffer used for MEM.pb
+* -- cMEMs
+* -- pppMEMs = pointer to receive ppMEMs
 * -- return
 */
-_Success_(return)
-DLLEXPORT BOOL LeechCore_Write(_In_ ULONG64 pa, _In_reads_(cb) PBYTE pb, _In_ DWORD cb);
+EXPORTED_FUNCTION _Success_(return)
+BOOL LcAllocScatter2(
+    _In_ DWORD cbData,
+    _Inout_updates_opt_(cbData) PBYTE pbData,
+    _In_ DWORD cMEMs,
+    _Out_ PPMEM_SCATTER *pppMEMs
+);
 
 /*
-* Write data to the target system if supported by the device.
-* -- pa
-* -- pb
-* -- cb
-* -- flags = 0 or LEECHCORE_FLAG_WRITE_*
+* Allocate and pre-initialize empty MEMs excluding the 0x1000 buffer which
+* will be accounted towards the pbData buffer in a contiguous way.
+* -- pbDataFirstPage = optional buffer of first page
+* -- pbDataLastPage = optional buffer of last page
+* -- cbData = size of pbData
+* -- pbData = buffer used for MEM.pb except first/last if exists
+* -- cMEMs
+* -- pppMEMs = pointer to receive ppMEMs
 * -- return
 */
-_Success_(return)
-DLLEXPORT BOOL LeechCore_WriteEx(_In_ ULONG64 pa, _In_reads_(cb) PBYTE pb, _In_ DWORD cb, _In_ DWORD flags);
+EXPORTED_FUNCTION _Success_(return)
+BOOL LcAllocScatter3(
+    _Inout_updates_opt_(0x1000) PBYTE pbDataFirstPage,
+    _Inout_updates_opt_(0x1000) PBYTE pbDataLastPage,
+    _In_ DWORD cbData,
+    _Inout_updates_opt_(cbData) PBYTE pbData,
+    _In_ DWORD cMEMs,
+    _Out_ PPMEM_SCATTER *pppMEMs
+);
 
 /*
-* Probe the memory of the target system to check whether it's readable or not.
-* Please note that not all devices support this natively.
-* -- pa = address to start probe from.
-* -- cPages = number of 4kB pages to probe.
-* -- pbResultMap = result map, 1 byte represents 1 page, 0 = fail, 1 = success.
-*       (individual page elements in pbResultMap must be set to 0 [fail] on call
-*       for probe to take place on individual page).
-* -- return = FALSE if not supported by underlying hardware, TRUE if supported.
+* Read memory in a scattered non-contiguous way. This is recommended for reads.
+* -- hLC
+* -- cMEMs
+* -- ppMEMs
 */
-_Success_(return)
-DLLEXPORT BOOL LeechCore_Probe(_In_ QWORD pa, _In_ DWORD cPages, _Inout_updates_bytes_(cPages) PBYTE pbResultMap);
+EXPORTED_FUNCTION
+VOID LcReadScatter(
+    _In_ HANDLE hLC,
+    _In_ DWORD cMEMs,
+    _Inout_ PPMEM_SCATTER ppMEMs
+);
+
+/*
+* Read memory in a contiguous way. Note that if multiple memory segments are
+* to be read LcReadScatter() may be more efficient.
+* -- hLC,
+* -- pa
+* -- cb
+* -- pb
+* -- return
+*/
+EXPORTED_FUNCTION _Success_(return)
+BOOL LcRead(
+    _In_ HANDLE hLC,
+    _In_ QWORD pa,
+    _In_ DWORD cb,
+    _Out_writes_(cb) PBYTE pb
+);
+
+/*
+* Write memory in a scattered non-contiguous way.
+* -- hLC
+* -- cMEMs
+* -- ppMEMs
+*/
+EXPORTED_FUNCTION
+VOID LcWriteScatter(
+    _In_ HANDLE hLC,
+    _In_ DWORD cMEMs,
+    _Inout_ PPMEM_SCATTER ppMEMs
+);
+
+/*
+* Write memory in a contiguous way.
+* -- hLC
+* -- pa
+* -- cb
+* -- pb
+* -- return
+*/
+EXPORTED_FUNCTION _Success_(return)
+BOOL LcWrite(
+    _In_ HANDLE hLC,
+    _In_ QWORD pa,
+    _In_ DWORD cb,
+    _In_reads_(cb) PBYTE pb
+);
 
 
 
 //-----------------------------------------------------------------------------
-// GET/SET DEVICE OPTIONS BELOW. SOME OPTIONS ARE GENERAL LEECHCORE OPTIONS
-// WHILE OTHER ARE DEVICE SPECIFIC. USE FUNCTIONS:
-// LeechCore_GetOption() AND LeechCore_GetOption() TO GET/SET OPTIONS.
-// FOR DEVICE-SPECIFIC OPTIONS PLEASE SEE INDIVIDUAL DEVICE FILES FOR MORE
-// DETAILED INFORMATION.
+// Get/Set/Command functionality may be used to query and/or update LeechCore
+// or its devices in various ways.
 //-----------------------------------------------------------------------------
-
-#define LEECHCORE_OPT_CORE_PRINTF_ENABLE                0x80000001  // RW
-#define LEECHCORE_OPT_CORE_VERBOSE                      0x80000002  // RW
-#define LEECHCORE_OPT_CORE_VERBOSE_EXTRA                0x80000003  // RW
-#define LEECHCORE_OPT_CORE_VERBOSE_EXTRA_TLP            0x80000004  // RW
-
-#define LEECHCORE_OPT_CORE_VERSION_MAJOR                0x01000001  // R
-#define LEECHCORE_OPT_CORE_VERSION_MINOR                0x01000002  // R
-#define LEECHCORE_OPT_CORE_VERSION_REVISION             0x01000003  // R
-#define LEECHCORE_OPT_CORE_FLAG_BACKEND_FUNCTIONS       0x01000004  // R
-
-#define LEECHCORE_OPT_MEMORYINFO_VALID                  0x02000001  // R
-#define LEECHCORE_OPT_MEMORYINFO_ADDR_MAX               0x02000002  // R
-#define LEECHCORE_OPT_MEMORYINFO_FLAG_32BIT             0x02000003  // R
-#define LEECHCORE_OPT_MEMORYINFO_FLAG_PAE               0x02000004  // R
-#define LEECHCORE_OPT_MEMORYINFO_OS_VERSION_MINOR       0x02000005  // R
-#define LEECHCORE_OPT_MEMORYINFO_OS_VERSION_MAJOR       0x02000006  // R
-#define LEECHCORE_OPT_MEMORYINFO_OS_DTB                 0x02000007  // R
-#define LEECHCORE_OPT_MEMORYINFO_OS_PFN                 0x02000008  // R
-#define LEECHCORE_OPT_MEMORYINFO_OS_PsLoadedModuleList  0x02000009  // R
-#define LEECHCORE_OPT_MEMORYINFO_OS_PsActiveProcessHead 0x0200000a  // R
-#define LEECHCORE_OPT_MEMORYINFO_OS_MACHINE_IMAGE_TP    0x0200000b  // R
-#define LEECHCORE_OPT_MEMORYINFO_OS_NUM_PROCESSORS      0x0200000c  // R
-#define LEECHCORE_OPT_MEMORYINFO_OS_SYSTEMTIME          0x0200000d  // R
-#define LEECHCORE_OPT_MEMORYINFO_OS_UPTIME              0x0200000e  // R
-#define LEECHCORE_OPT_MEMORYINFO_OS_KERNELBASE          0x0200000f  // R
-#define LEECHCORE_OPT_MEMORYINFO_OS_KERNELHINT          0x02000010  // R
-#define LEECHCORE_OPT_MEMORYINFO_OS_KdDebuggerDataBlock 0x02000011  // R
-
-#define LEECHCORE_OPT_FPGA_PROBE_MAXPAGES               0x03000001  // RW
-#define LEECHCORE_OPT_FPGA_RX_FLUSH_LIMIT               0x03000002  // RW
-#define LEECHCORE_OPT_FPGA_MAX_SIZE_RX                  0x03000003  // RW
-#define LEECHCORE_OPT_FPGA_MAX_SIZE_TX                  0x03000004  // RW
-#define LEECHCORE_OPT_FPGA_DELAY_PROBE_READ             0x03000005  // RW - uS
-#define LEECHCORE_OPT_FPGA_DELAY_PROBE_WRITE            0x03000006  // RW - uS
-#define LEECHCORE_OPT_FPGA_DELAY_WRITE                  0x03000007  // RW - uS
-#define LEECHCORE_OPT_FPGA_DELAY_READ                   0x03000008  // RW - uS
-#define LEECHCORE_OPT_FPGA_RETRY_ON_ERROR               0x03000009  // RW
-#define LEECHCORE_OPT_FPGA_DEVICE_ID                    0x03000080  // R
-#define LEECHCORE_OPT_FPGA_FPGA_ID                      0x03000081  // R
-#define LEECHCORE_OPT_FPGA_VERSION_MAJOR                0x03000082  // R
-#define LEECHCORE_OPT_FPGA_VERSION_MINOR                0x03000083  // R
 
 /*
-* Set a device specific option value.
-* -- fOption
-* -- pqwValue = pointer to QWORD to receive option value.
-* -- return
+* Set an option as defined by LC_OPT_*. (R option).
+* -- hLC
+* -- fOption = LC_OPT_*
+* -- cbData
+* -- pbData
+* -- pcbData
 */
-_Success_(return)
-DLLEXPORT BOOL LeechCore_GetOption(_In_ ULONG64 fOption, _Out_ PULONG64 pqwValue);
+EXPORTED_FUNCTION _Success_(return)
+BOOL LcGetOption(
+    _In_ HANDLE hLC,
+    _In_ QWORD fOption,
+    _Out_ PQWORD pqwValue
+);
 
 /*
-* Set a device specific option value.
-* -- fOption
-* -- qwValue
-* -- return
+* Get an option as defined by LC_OPT_*. (W option).
+* -- hLC
+* -- fOption = LC_OPT_*
+* -- cbData
+* -- pbData
 */
-_Success_(return)
-DLLEXPORT BOOL LeechCore_SetOption(_In_ ULONG64 fOption, _In_ ULONG64 qwValue);
+EXPORTED_FUNCTION _Success_(return)
+BOOL LcSetOption(
+    _In_ HANDLE hLC,
+    _In_ QWORD fOption,
+    _In_ QWORD qwValue
+);
 
+/*
+* Execute a command and retrieve a result (if any) at the same time.
+* NB! If *ppbDataOut contains a memory allocation on exit this should be free'd
+*     by calling LcMemFree().
+* CALLER LcFreeMem: *ppbDataOut
+* -- hLC
+* -- fCommand = LC_CMD_*
+* -- cbDataIn
+* -- pbDataIn
+* -- ppbDataOut
+* -- pcbDataOut
+*/
+EXPORTED_FUNCTION _Success_(return)
+BOOL LcCommand(
+    _In_ HANDLE hLC,
+    _In_ QWORD fCommand,
+    _In_ DWORD cbDataIn,
+    _In_reads_opt_(cbDataIn) PBYTE pbDataIn,
+    _Out_opt_ PBYTE *ppbDataOut,
+    _Out_opt_ PDWORD pcbDataOut
+);
 
+#define LC_OPT_CORE_PRINTF_ENABLE                   0x4000000100000000  // RW
+#define LC_OPT_CORE_VERBOSE                         0x4000000200000000  // RW
+#define LC_OPT_CORE_VERBOSE_EXTRA                   0x4000000300000000  // RW
+#define LC_OPT_CORE_VERBOSE_EXTRA_TLP               0x4000000400000000  // RW
+#define LC_OPT_CORE_VERSION_MAJOR                   0x4000000500000000  // R
+#define LC_OPT_CORE_VERSION_MINOR                   0x4000000600000000  // R
+#define LC_OPT_CORE_VERSION_REVISION                0x4000000700000000  // R
+#define LC_OPT_CORE_ADDR_MAX                        0x1000000800000000  // R
+#define LC_OPT_CORE_STATISTICS_CALL_COUNT           0x4000000900000000  // R [lo-dword: LC_STATISTICS_ID_*]
+#define LC_OPT_CORE_STATISTICS_CALL_TIME            0x4000000a00000000  // R [lo-dword: LC_STATISTICS_ID_*]
+#define LC_OPT_CORE_VOLATILE                        0x1000000b00000000  // R
+#define LC_OPT_CORE_READONLY                        0x1000000c00000000  // R
 
-//-----------------------------------------------------------------------------
-// TRANSFER DEVICE DEPENDANT COMMANDS OR DATA TO/FROM UNDERLYING DEVICES AND
-// PERFORM ACTIONS USING THE LeechCore_CommandData() FUNCTION.
-//-----------------------------------------------------------------------------
+#define LC_OPT_MEMORYINFO_VALID                     0x0200000100000000  // R
+#define LC_OPT_MEMORYINFO_FLAG_32BIT                0x0200000300000000  // R
+#define LC_OPT_MEMORYINFO_FLAG_PAE                  0x0200000400000000  // R
+#define LC_OPT_MEMORYINFO_ARCH                      0x0200001200000000  // R - LC_ARCH_TP
+#define LC_OPT_MEMORYINFO_OS_VERSION_MINOR          0x0200000500000000  // R
+#define LC_OPT_MEMORYINFO_OS_VERSION_MAJOR          0x0200000600000000  // R
+#define LC_OPT_MEMORYINFO_OS_DTB                    0x0200000700000000  // R
+#define LC_OPT_MEMORYINFO_OS_PFN                    0x0200000800000000  // R
+#define LC_OPT_MEMORYINFO_OS_PsLoadedModuleList     0x0200000900000000  // R
+#define LC_OPT_MEMORYINFO_OS_PsActiveProcessHead    0x0200000a00000000  // R
+#define LC_OPT_MEMORYINFO_OS_MACHINE_IMAGE_TP       0x0200000b00000000  // R
+#define LC_OPT_MEMORYINFO_OS_NUM_PROCESSORS         0x0200000c00000000  // R
+#define LC_OPT_MEMORYINFO_OS_SYSTEMTIME             0x0200000d00000000  // R
+#define LC_OPT_MEMORYINFO_OS_UPTIME                 0x0200000e00000000  // R
+#define LC_OPT_MEMORYINFO_OS_KERNELBASE             0x0200000f00000000  // R
+#define LC_OPT_MEMORYINFO_OS_KERNELHINT             0x0200001000000000  // R
+#define LC_OPT_MEMORYINFO_OS_KdDebuggerDataBlock    0x0200001100000000  // R
 
-#define LEECHCORE_COMMANDDATA_FPGA_WRITE_TLP            0x00000101  // R
-#define LEECHCORE_COMMANDDATA_FPGA_LISTEN_TLP           0x00000102  // R
-#define LEECHCORE_COMMANDDATA_FPGA_PCIECFGSPACE         0x00000103  // R
-#define LEECHCORE_COMMANDDATA_FPGA_CFGREGPCIE           0x00000104  // RW - [high-part fOption = address]
-#define LEECHCORE_COMMANDDATA_FPGA_CFGREGCFG            0x00000105  // RW - [high-part fOption = address]
-#define LEECHCORE_COMMANDDATA_FPGA_CFGREGDRP            0x00000106  // RW - [high-part fOption = address]
-#define LEECHCORE_COMMANDDATA_FPGA_CFGREGCFG_MARKWR     0x00000107  // W  - write with mask [bytes: 0-1: data, 2-3: mask] [high-part fOption = address]
-#define LEECHCORE_COMMANDDATA_FPGA_CFGREGPCIE_MARKWR    0x00000108  // W  - write with mask [bytes: 0-1: data, 2-3: mask] [high-part fOption = address]
-#define LEECHCORE_COMMANDDATA_FPGA_PCIECFGSPACE_WR      0x00000109  // W
-#define LEECHCORE_COMMANDDATA_FPGA_CFGREG_DEBUGPRINT    0x0000010a  //
-#define LEECHCORE_COMMANDDATA_FILE_DUMPHEADER_GET       0x00000201  // R
-#define LEECHCORE_COMMANDDATA_STATISTICS_GET            0x80000100  // R
+#define LC_OPT_FPGA_PROBE_MAXPAGES                  0x0300000100000000  // RW
+#define LC_OPT_FPGA_MAX_SIZE_RX                     0x0300000300000000  // RW
+#define LC_OPT_FPGA_MAX_SIZE_TX                     0x0300000400000000  // RW
+#define LC_OPT_FPGA_DELAY_PROBE_READ                0x0300000500000000  // RW - uS
+#define LC_OPT_FPGA_DELAY_PROBE_WRITE               0x0300000600000000  // RW - uS
+#define LC_OPT_FPGA_DELAY_WRITE                     0x0300000700000000  // RW - uS
+#define LC_OPT_FPGA_DELAY_READ                      0x0300000800000000  // RW - uS
+#define LC_OPT_FPGA_RETRY_ON_ERROR                  0x0300000900000000  // RW
+#define LC_OPT_FPGA_DEVICE_ID                       0x0300008000000000  // RW - bus:dev:fn (ex: 04:00.0 == 0x0400).
+#define LC_OPT_FPGA_FPGA_ID                         0x0300008100000000  // R
+#define LC_OPT_FPGA_VERSION_MAJOR                   0x0300008200000000  // R
+#define LC_OPT_FPGA_VERSION_MINOR                   0x0300008300000000  // R
+#define LC_OPT_FPGA_ALGO_TINY                       0x0300008400000000  // RW - 1/0 use tiny 128-byte/tlp read algorithm.
+#define LC_OPT_FPGA_ALGO_SYNCHRONOUS                0x0300008500000000  // RW - 1/0 use synchronous (old) read algorithm.
+#define LC_OPT_FPGA_CFGSPACE_XILINX                 0x0300008600000000  // RW - [lo-dword: register address in bytes] [bytes: 0-3: data, 4-7: byte_enable(if wr/set); top bit = cfg_mgmt_wr_rw1c_as_rw]
+#define LC_OPT_FPGA_TLP_READ_CB_WITHINFO            0x0300009000000000  // RW - 1/0 call TLP read callback with additional string info in szInfo
+#define LC_OPT_FPGA_TLP_READ_CB_FILTERCPL           0x0300009100000000  // RW - 1/0 call TLP read callback with memory read completions from read calls filtered
 
-#define LEECHCORE_STATISTICS_MAGIC                      0xffff6550
-#define LEECHCORE_STATISTICS_VERSION                        0x0001
-#define LEECHCORE_STATISTICS_ID_OPEN                          0x00
-#define LEECHCORE_STATISTICS_ID_READSCATTER                   0x01
-#define LEECHCORE_STATISTICS_ID_WRITE                         0x02
-#define LEECHCORE_STATISTICS_ID_PROBE                         0x03
-#define LEECHCORE_STATISTICS_ID_GETOPTION                     0x04
-#define LEECHCORE_STATISTICS_ID_SETOPTION                     0x05
-#define LEECHCORE_STATISTICS_ID_COMMANDDATA                   0x06
-#define LEECHCORE_STATISTICS_ID_COMMANDSVC                    0x07
-#define LEECHCORE_STATISTICS_ID_MAX                           0x07
+#define LC_CMD_FPGA_PCIECFGSPACE                    0x0000010300000000  // R
+#define LC_CMD_FPGA_CFGREGPCIE                      0x0000010400000000  // RW - [lo-dword: register address]
+#define LC_CMD_FPGA_CFGREGCFG                       0x0000010500000000  // RW - [lo-dword: register address]
+#define LC_CMD_FPGA_CFGREGDRP                       0x0000010600000000  // RW - [lo-dword: register address]
+#define LC_CMD_FPGA_CFGREGCFG_MARKWR                0x0000010700000000  // W  - write with mask [lo-dword: register address] [bytes: 0-1: data, 2-3: mask]
+#define LC_CMD_FPGA_CFGREGPCIE_MARKWR               0x0000010800000000  // W  - write with mask [lo-dword: register address] [bytes: 0-1: data, 2-3: mask]
+#define LC_CMD_FPGA_CFGREG_DEBUGPRINT               0x0000010a00000000  // N/A
+#define LC_CMD_FPGA_PROBE                           0x0000010b00000000  // RW
+#define LC_CMD_FPGA_CFGSPACE_SHADOW_RD              0x0000010c00000000  // R
+#define LC_CMD_FPGA_CFGSPACE_SHADOW_WR              0x0000010d00000000  // W  - [lo-dword: config space write base address]
+#define LC_CMD_FPGA_TLP_WRITE_SINGLE                0x0000011000000000  // W  - write single tlp BYTE:s
+#define LC_CMD_FPGA_TLP_WRITE_MULTIPLE              0x0000011100000000  // W  - write multiple LC_TLP:s
+#define LC_CMD_FPGA_TLP_TOSTRING                    0x0000011200000000  // RW - convert single TLP to LPSTR; *pcbDataOut includes NULL terminator.
 
-static LPCSTR LEECHCORE_STATISTICS_NAME[] = {
-    "LeechCore_Open",
-    "LeechCore_ReadScatter",
-    "LeechCore_Write",
-    "LeechCore_Probe",
-    "LeechCore_GetOption",
-    "LeechCore_SetOption",
-    "LeechCore_CommandData",
-    "LeechCore_CommandSvc"
+#define LC_CMD_FPGA_TLP_CONTEXT                     0x2000011400000000  // W - set/unset TLP user-defined context to be passed to callback function. (pbDataIn == LPVOID user context). [not remote].
+#define LC_CMD_FPGA_TLP_CONTEXT_RD                  0x2000011b00000000  // R - get TLP user-defined context to be passed to callback function. [not remote].
+#define LC_CMD_FPGA_TLP_FUNCTION_CALLBACK           0x2000011500000000  // W - set/unset TLP callback function (pbDataIn == PLC_TLP_CALLBACK). [not remote].
+#define LC_CMD_FPGA_TLP_FUNCTION_CALLBACK_RD        0x2000011c00000000  // R - get TLP callback function. [not remote].
+#define LC_CMD_FPGA_BAR_CONTEXT                     0x2000012000000000  // W - set/unset BAR user-defined context to be passed to callback function. (pbDataIn == LPVOID user context). [not remote].
+#define LC_CMD_FPGA_BAR_CONTEXT_RD                  0x2000012100000000  // R - get BAR user-defined context to be passed to callback function. [not remote].
+#define LC_CMD_FPGA_BAR_FUNCTION_CALLBACK           0x2000012200000000  // W - set/unset BAR callback function (pbDataIn == PLC_BAR_CALLBACK). [not remote].
+#define LC_CMD_FPGA_BAR_FUNCTION_CALLBACK_RD        0x2000012300000000  // R - get BAR callback function. [not remote].
+#define LC_CMD_FPGA_BAR_INFO                        0x0000012400000000  // R - get BAR info (pbDataOut == LC_BAR_INFO[6]).
+
+#define LC_CMD_FILE_DUMPHEADER_GET                  0x0000020100000000  // R
+
+#define LC_CMD_STATISTICS_GET                       0x4000010000000000  // R
+#define LC_CMD_MEMMAP_GET                           0x4000020000000000  // R  - MEMMAP as LPSTR
+#define LC_CMD_MEMMAP_SET                           0x4000030000000000  // W  - MEMMAP as LPSTR
+#define LC_CMD_MEMMAP_GET_STRUCT                    0x4000040000000000  // R  - MEMMAP as LC_MEMMAP_ENTRY[]
+#define LC_CMD_MEMMAP_SET_STRUCT                    0x4000050000000000  // W  - MEMMAP as LC_MEMMAP_ENTRY[]
+
+#define LC_CMD_AGENT_EXEC_PYTHON                    0x8000000100000000  // RW - [lo-dword: optional timeout in ms]
+#define LC_CMD_AGENT_EXIT_PROCESS                   0x8000000200000000  //    - [lo-dword: process exit code]
+#define LC_CMD_AGENT_VFS_LIST                       0x8000000300000000  // RW
+#define LC_CMD_AGENT_VFS_READ                       0x8000000400000000  // RW
+#define LC_CMD_AGENT_VFS_WRITE                      0x8000000500000000  // RW
+#define LC_CMD_AGENT_VFS_OPT_GET                    0x8000000600000000  // RW
+#define LC_CMD_AGENT_VFS_OPT_SET                    0x8000000700000000  // RW
+#define LC_CMD_AGENT_VFS_INITIALIZE                 0x8000000800000000  // RW
+#define LC_CMD_AGENT_VFS_CONSOLE                    0x8000000900000000  // RW
+
+#define LC_CMD_AGENT_VFS_REQ_VERSION                0xfeed0001
+#define LC_CMD_AGENT_VFS_RSP_VERSION                0xfeee0001
+
+#define LC_STATISTICS_VERSION                       0xe1a10002
+#define LC_STATISTICS_ID_OPEN                       0x00
+#define LC_STATISTICS_ID_READ                       0x01
+#define LC_STATISTICS_ID_READSCATTER                0x02
+#define LC_STATISTICS_ID_WRITE                      0x03
+#define LC_STATISTICS_ID_WRITESCATTER               0x04
+#define LC_STATISTICS_ID_GETOPTION                  0x05
+#define LC_STATISTICS_ID_SETOPTION                  0x06
+#define LC_STATISTICS_ID_COMMAND                    0x07
+#define LC_STATISTICS_ID_MAX                        0x07
+
+typedef struct tdLC_CMD_AGENT_VFS_REQ {
+    DWORD dwVersion;
+    DWORD _FutureUse;
+    CHAR uszPathFile[2*MAX_PATH];   // file path to list/read/write
+    union {
+        QWORD qwOffset;             // offset to read/write
+        QWORD fOption;              // option to get/set (qword data in *pb)
+    };
+    DWORD dwLength;                 // length to read
+    DWORD cb;
+    BYTE pb[0];
+} LC_CMD_AGENT_VFS_REQ, *PLC_CMD_AGENT_VFS_REQ;
+
+typedef struct tdLC_CMD_AGENT_VFS_RSP {
+    DWORD dwVersion;
+    DWORD dwStatus;                 // ntstatus of read/write
+    DWORD cbReadWrite;              // number of bytes read/written
+    DWORD _FutureUse[2];
+    DWORD cb;
+    BYTE pb[0];
+} LC_CMD_AGENT_VFS_RSP, *PLC_CMD_AGENT_VFS_RSP;
+
+static LPCSTR LC_STATISTICS_NAME[] = {
+    "LcOpen",
+    "LcRead",
+    "LcReadScatter",
+    "LcWrite",
+    "LcWriteScatter",
+    "LcGetOption",
+    "LcSetOption",
+    "LcCommand",
 };
 
-typedef struct tdLEECHCORE_STATISTICS {
-    DWORD magic;
-    WORD version;
-    WORD Reserved0;
-    DWORD Reserved1;
+typedef struct tdLC_STATISTICS {
+    DWORD dwVersion;
+    DWORD _Reserved;
     QWORD qwFreq;
     struct {
         QWORD c;
         QWORD tm;   // total time in qwFreq ticks
-    } Call[0x10];
-} LEECHCORE_STATISTICS, *PLEECHCORE_STATISTICS;
+    } Call[LC_STATISTICS_ID_MAX + 1];
+} LC_STATISTICS, *PLC_STATISTICS;
+
+typedef struct tdLC_MEMMAP_ENTRY {
+    QWORD pa;
+    QWORD cb;
+    QWORD paRemap;
+} LC_MEMMAP_ENTRY, *PLC_MEMMAP_ENTRY;
+
+typedef enum tdLC_ARCH_TP {
+    LC_ARCH_NA      = 0,
+    LC_ARCH_X86     = 1,
+    LC_ARCH_X86PAE  = 2,
+    LC_ARCH_X64     = 3,
+    LC_ARCH_ARM64   = 4,
+} LC_ARCH_TP;
+
+
+
+//-----------------------------------------------------------------------------
+// RAW TLP READ/WRITE SUPPORT:
+//-----------------------------------------------------------------------------
 
 /*
-* Transfer device dependant commands/data to/from the underlying device and
-* perform device dependant actions.
-* -- fOption
-* -- cbDataIn
-* -- pbDataIn
-* -- pbDataOut
-* -- cbDataOut
-* -- pcbDataOut
-* -- return
+* TLP structure to be used with LC_CMD_FPGA_TLP_WRITE_MULTIPLE.
 */
-_Success_(return)
-DLLEXPORT BOOL LeechCore_CommandData(
-    _In_ ULONG64 fOption,
-    _In_reads_(cbDataIn) PBYTE pbDataIn,
-    _In_ DWORD cbDataIn,
-    _Out_writes_opt_(cbDataOut) PBYTE pbDataOut,
-    _In_ DWORD cbDataOut,
-    _Out_opt_ PDWORD pcbDataOut
-);
-
-#define LEECHCORE_AGENTCOMMAND_EXEC_PYTHON_INMEM    0x1166000000000001
-#define LEECHCORE_AGENTCOMMAND_EXITPROCESS          0x1166000000000010
+typedef struct tdLC_TLP {
+    DWORD cb;
+    DWORD _Reserved1;
+    PBYTE pb;
+} LC_TLP, *PLC_TLP;
 
 /*
-* Transfer commands/data to/from the remote agent (if it exists).
-* NB! USER-FREE: ppbDataOut (LocalFree)
-* -- fCommand = the option / command to the remote service as defined in LEECHCORE_AGENTCOMMAND_*
-* -- fDataIn = optional 64-bit tiny input value
-* -- cbDataIn
-* -- pbDataIn
-* -- ppbDataOut =  ptr to receive function allocated output - must be LocalFree'd by caller!
-* -- pcbDataOut = ptr to receive length of *pbDataOut.
-* -- return
+* Custom FPGA callback function called when a TLP is received.
+* Callback function set by command LC_CMD_FPGA_TLP_FUNCTION_CALLBACK.
+* User-defined context is set by command: LC_CMD_FPGA_TLP_CONTEXT.
 */
-_Success_(return)
-DLLEXPORT BOOL LeechCore_AgentCommand(
-    _In_ ULONG64 fCommand,
-    _In_ ULONG64 fDataIn,
-    _In_reads_(cbDataIn) PBYTE pbDataIn,
-    _In_ DWORD cbDataIn,
-    _Out_writes_opt_(*pcbDataOut) PBYTE *ppbDataOut,
-    _Out_opt_ PDWORD pcbDataOut
+typedef VOID(*PLC_TLP_FUNCTION_CALLBACK)(
+    _In_opt_ PVOID ctx,
+    _In_ DWORD cbTlp,
+    _In_ PBYTE pbTlp,
+    _In_opt_ DWORD cbInfo,
+    _In_opt_ LPSTR szInfo
 );
+
+#define LC_TLP_FUNCTION_CALLBACK_DISABLE        (PLC_TLP_FUNCTION_CALLBACK)(NULL)
+#define LC_TLP_FUNCTION_CALLBACK_DUMMY          (PLC_TLP_FUNCTION_CALLBACK)(-1)
+
+
+
+//-----------------------------------------------------------------------------
+// PCIE BAR SUPPORT:
+//-----------------------------------------------------------------------------
+
+typedef struct tdLC_BAR {
+    BOOL fValid;
+    BOOL fIO;
+    BOOL f64Bit;
+    BOOL fPrefetchable;
+    DWORD _Filler[3];
+    DWORD iBar;
+    QWORD pa;
+    QWORD cb;
+} LC_BAR, *PLC_BAR;
+
+typedef struct tdLC_BAR_REQUEST {
+    PVOID ctx;              // user context (set by command LC_CMD_FPGA_BAR_CONTEXT)
+    PLC_BAR pBar;           // BAR info
+    BYTE bTag;              // TLP tag (0-255)
+    BYTE bFirstBE;          // First byte enable (0-3) [relevant for writes]
+    BYTE bLastBE;           // Last byte enable (0-3) [relevant for writes]
+    BYTE _Filler;
+    BOOL f64;               // 64-bit bar access (false = 32-bit)
+    BOOL fRead;             // BAR read request, called function should update pbData with read data and set fReadReply = TRUE on success.
+    BOOL fReadReply;        // Read success - should be updated by called function upon read success (after updating pbData).
+    BOOL fWrite;            // BAR write request (no reply should be sent, check byte-enables bFirstBE/bLastBE)
+    DWORD cbData;           // number of bytes to read/write
+    QWORD oData;            // data offset in BAR.
+    BYTE pbData[4096];      // bytes to write or read data (to be updated by called function).
+} LC_BAR_REQUEST, *PLC_BAR_REQUEST;
+
+/*
+* Custom FPGA callback function to be called when BAR read/write is received.
+* Callback function set by command LC_CMD_FPGA_BAR_FUNCTION_CALLBACK.
+* User-defined context is set by command: LC_CMD_FPGA_BAR_CONTEXT.
+* Read reply is sent by updating pbData with read data and fReadReply = TRUE.
+* To return Unsupported Request (UR) set fReadReply = FALSE on a MRd request.
+*/
+typedef VOID(*PLC_BAR_FUNCTION_CALLBACK)(_Inout_ PLC_BAR_REQUEST pBarRequest);
+
+#define LC_BAR_FUNCTION_CALLBACK_DISABLE        (PLC_BAR_FUNCTION_CALLBACK)(NULL)
+#define LC_BAR_FUNCTION_CALLBACK_ZEROBAR        (PLC_BAR_FUNCTION_CALLBACK)(-1)
+
 
 #ifdef __cplusplus
 }

--- a/DMALib/libs/vmmdll.h
+++ b/DMALib/libs/vmmdll.h
@@ -1,13 +1,19 @@
-// vmmdll.h : header file to include in projects that use vmm.dll either as
-// stand anlone projects or as native plugins to vmm.dll.
+// vmmdll.h : header file to include in projects that use vmm.dll / vmm.so
+// 
+// Please also consult the guide at: https://github.com/ufrisk/MemProcFS/wiki
+// 
+// U/W functions
+// =============
+// Windows may access both UTF-8 *U and Wide-Char *W versions of functions
+// while Linux may only access UTF-8 versions. Some functionality may also
+// be degraded or unavailable on Linux.
 //
-// (c) Ulf Frisk, 2018-2020
+// (c) Ulf Frisk, 2018-2023
 // Author: Ulf Frisk, pcileech@frizk.net
 //
-// Header Version: 3.2
+// Header Version: 5.8
 //
 
-#include <windows.h>
 #include "leechcore.h"
 
 #ifndef __VMMDLL_H__
@@ -16,154 +22,322 @@
 extern "C" {
 #endif /* __cplusplus */
 
+#ifdef _WIN32
 
-//-----------------------------------------------------------------------------
-// INITIALIZATION FUNCTIONALITY BELOW:
-// Choose one way of initialzing the VMM / Memory Process File System.
-//-----------------------------------------------------------------------------
+#include <Windows.h>
+#undef EXPORTED_FUNCTION
+#define EXPORTED_FUNCTION
+    typedef unsigned __int64                    QWORD, * PQWORD;
 
-/*
-* Initialize VMM.DLL with command line parameters. For a more detailed info
-* about the parameters please see github wiki for MemProcFS and LeechCore.
-* NB! LeechCore initialization parameters are _also_ valid to this function.
-* Important parameters are:
-*    -printf = show printf style outputs.
-*    -v -vv -vvv = extra verbosity levels.
-*    -device = device as on format for LeechCore - please see leechcore.h or
-*              Github documentation for additional information. Some values
-*              are: <file>, fpga, usb3380, hvsavedstate, totalmeltdown, pmem
-*    -remote = remote LeechCore instance - please see leechcore.h or Github
-*              documentation for additional information.
-*    -norefresh = disable background refreshes (even if backing memory is
-*              volatile memory).
-*    -symbolserverdisable = disable symbol server until user change.
-*              This parameter will take precedence over registry settings.
-*    -pagefile[0-9] = page file(s) to use in addition to physical memory.
-*              Normally pagefile.sys have index 0 and swapfile.sys index 1.
-*              Page files are in constant flux - do not use if time diff
-*              between memory dump and page files are more than few minutes.
-*              Example: 'pagefile0 swapfile.sys'
-*    -waitinitialize = Wait for initialization to complete before returning.
-*              Normal use is that some initialization is done asynchronously
-*              and may not be completed when initialization call is completed.
-*              This includes virtual memory compression, registry and more.
-*              Example: '-waitinitialize'
-*
-* -- argc
-* -- argv
-* -- return = success/fail
-*/
-_Success_(return)
-BOOL VMMDLL_Initialize(_In_ DWORD argc, _In_ LPSTR argv[]);
+#endif /* _WIN32 */
+#ifdef LINUX
 
-/*
-* Close an initialized instance of VMM.DLL and clean up all allocated resources
-* including plugins, linked PCILeech.DLL and other memory resources.
-* -- return = success/fail.
-*/
-_Success_(return)
-BOOL VMMDLL_Close();
+#include <inttypes.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#undef EXPORTED_FUNCTION
+#define EXPORTED_FUNCTION                   __attribute__((visibility("default")))
+    typedef void                                VOID, * PVOID, * HANDLE, ** PHANDLE, * HMODULE;
+    typedef long long unsigned int              QWORD, * PQWORD, ULONG64, * PULONG64;
+    typedef size_t                              SIZE_T, * PSIZE_T;
+    typedef uint64_t                            FILETIME, * PFILETIME;
+    typedef uint32_t                            DWORD, * PDWORD, * LPDWORD, BOOL, * PBOOL, NTSTATUS;
+    typedef uint16_t                            WORD, * PWORD;
+    typedef uint8_t                             BYTE, * PBYTE, * LPBYTE, UCHAR;
+    typedef char                                CHAR, * PCHAR, * LPSTR, * LPCSTR;
+    typedef uint16_t                            WCHAR, * PWCHAR, * LPWSTR, * LPCWSTR;
+#define MAX_PATH                            260
+#define _In_
+#define _In_z_
+#define _In_opt_
+#define _In_reads_(x)
+#define _In_reads_bytes_(x)
+#define _In_reads_opt_(x)
+#define _Inout_
+#define _Inout_bytecount_(x)
+#define _Inout_opt_
+#define _Inout_updates_opt_(x)
+#define _Out_
+#define _Out_opt_
+#define _Out_writes_(x)
+#define _Out_writes_bytes_opt_(x)
+#define _Out_writes_opt_(x)
+#define _Out_writes_to_(x,y)
+#define _When_(x,y)
+#define _Frees_ptr_opt_
+#define _Post_ptr_invalid_
+#define _Check_return_opt_
+#define _Printf_format_string_
+#define _Success_(x)
 
-/*
-* Perform a force refresh of all internal caches including:
-* - process listings
-* - memory cache
-* - page table cache
-* WARNING: function may take some time to execute!
-* -- dwReserved = reserved future use - must be zero
-* -- return = sucess/fail
-*/
-_Success_(return)
-BOOL VMMDLL_Refresh(_In_ DWORD dwReserved);
+#endif /* LINUX */
 
-/*
-* Free memory allocated by the VMMDLL.
-* -- pvMem
-*/
-VOID VMMDLL_MemFree(_Frees_ptr_opt_ PVOID pvMem);
-
-
-//-----------------------------------------------------------------------------
-// CONFIGURATION SETTINGS BELOW:
-// Configure the memory process file system or the underlying memory
-// acquisition devices.
-//-----------------------------------------------------------------------------
-
-/*
-* Options used together with the functions: VMMDLL_ConfigGet & VMMDLL_ConfigSet
-* Options are defined with either: VMMDLL_OPT_* in this header file or as
-* LEECHCORE_OPT_* in leechcore.h
-* For more detailed information check the sources for individual device types.
-*/
-#define VMMDLL_OPT_CORE_PRINTF_ENABLE                   0x80000001  // RW
-#define VMMDLL_OPT_CORE_VERBOSE                         0x80000002  // RW
-#define VMMDLL_OPT_CORE_VERBOSE_EXTRA                   0x80000003  // RW
-#define VMMDLL_OPT_CORE_VERBOSE_EXTRA_TLP               0x80000004  // RW
-#define VMMDLL_OPT_CORE_MAX_NATIVE_ADDRESS              0x80000005  // R
-#define VMMDLL_OPT_CORE_SYSTEM                          0x80000007  // R
-#define VMMDLL_OPT_CORE_MEMORYMODEL                     0x80000008  // R
-
-#define VMMDLL_OPT_CONFIG_IS_REFRESH_ENABLED            0x40000001  // R - 1/0
-#define VMMDLL_OPT_CONFIG_TICK_PERIOD                   0x40000002  // RW - base tick period in ms
-#define VMMDLL_OPT_CONFIG_READCACHE_TICKS               0x40000003  // RW - memory cache validity period (in ticks)
-#define VMMDLL_OPT_CONFIG_TLBCACHE_TICKS                0x40000004  // RW - page table (tlb) cache validity period (in ticks)
-#define VMMDLL_OPT_CONFIG_PROCCACHE_TICKS_PARTIAL       0x40000005  // RW - process refresh (partial) period (in ticks)
-#define VMMDLL_OPT_CONFIG_PROCCACHE_TICKS_TOTAL         0x40000006  // RW - process refresh (full) period (in ticks)
-#define VMMDLL_OPT_CONFIG_VMM_VERSION_MAJOR             0x40000007  // R
-#define VMMDLL_OPT_CONFIG_VMM_VERSION_MINOR             0x40000008  // R
-#define VMMDLL_OPT_CONFIG_VMM_VERSION_REVISION          0x40000009  // R
-#define VMMDLL_OPT_CONFIG_STATISTICS_FUNCTIONCALL       0x4000000A  // RW - enable function call statistics (.status/statistics_fncall file)
-#define VMMDLL_OPT_CONFIG_IS_PAGING_ENABLED             0x4000000B  // RW - 1/0
-
-#define VMMDLL_OPT_WIN_VERSION_MAJOR                    0x40000101  // R
-#define VMMDLL_OPT_WIN_VERSION_MINOR                    0x40000102  // R
-#define VMMDLL_OPT_WIN_VERSION_BUILD                    0x40000103  // R
-
-static const LPSTR VMMDLL_MEMORYMODEL_TOSTRING[4] = { "N/A", "X86", "X86PAE", "X64" };
-
-typedef enum tdVMMDLL_MEMORYMODEL_TP {
-    VMMDLL_MEMORYMODEL_NA       = 0,
-    VMMDLL_MEMORYMODEL_X86      = 1,
-    VMMDLL_MEMORYMODEL_X86PAE   = 2,
-    VMMDLL_MEMORYMODEL_X64      = 3
-} VMMDLL_MEMORYMODEL_TP;
-
-typedef enum tdVMMDLL_SYSTEM_TP {
-    VMMDLL_SYSTEM_UNKNOWN_X64   = 1,
-    VMMDLL_SYSTEM_WINDOWS_X64   = 2,
-    VMMDLL_SYSTEM_UNKNOWN_X86   = 3,
-    VMMDLL_SYSTEM_WINDOWS_X86   = 4
-} VMMDLL_SYSTEM_TP;
-
-/*
-* Set a device specific option value. Please see defines VMMDLL_OPT_* for infor-
-* mation about valid option values. Please note that option values may overlap
-* between different device types with different meanings.
-* -- fOption
-* -- pqwValue = pointer to ULONG64 to receive option value.
-* -- return = success/fail.
-*/
-_Success_(return)
-BOOL VMMDLL_ConfigGet(_In_ ULONG64 fOption, _Out_ PULONG64 pqwValue);
-
-/*
-* Set a device specific option value. Please see defines VMMDLL_OPT_* for infor-
-* mation about valid option values. Please note that option values may overlap
-* between different device types with different meanings.
-* -- fOption
-* -- qwValue
-* -- return = success/fail.
-*/
-_Success_(return)
-BOOL VMMDLL_ConfigSet(_In_ ULONG64 fOption, _In_ ULONG64 qwValue);
+    typedef struct tdVMM_HANDLE* VMM_HANDLE;
+    typedef struct tdVMMVM_HANDLE* VMMVM_HANDLE;
+    typedef BYTE                    OPAQUE_OB_HEADER[0x40];
 
 
 
-//-----------------------------------------------------------------------------
-// VFS - VIRTUAL FILE SYSTEM FUNCTIONALITY BELOW:
-// This is the core of the memory process file system. All implementation and
-// analysis towards the file system is possible by using functionality below. 
-//-----------------------------------------------------------------------------
+    //-----------------------------------------------------------------------------
+    // INITIALIZATION FUNCTIONALITY BELOW:
+    // Choose one way of initializing the VMM / MemProcFS.
+    //-----------------------------------------------------------------------------
+
+    /*
+    * Initialize VMM.DLL with command line parameters. For a more detailed info
+    * about the parameters please see github wiki for MemProcFS and LeechCore.
+    * NB! LeechCore initialization parameters are _also_ valid to this function.
+    * Important parameters are:
+    *    -printf = show printf style outputs.
+    *    -v -vv -vvv = extra verbosity levels.
+    *    -device = device as on format for LeechCore - please see leechcore.h or
+    *              Github documentation for additional information. Some values
+    *              are: <file>, fpga, usb3380, hvsavedstate, totalmeltdown, pmem
+    *    -remote = remote LeechCore instance - please see leechcore.h or Github
+    *              documentation for additional information.
+    *    -norefresh = disable background refreshes (even if backing memory is
+    *              volatile memory).
+    *    -memmap = specify a physical memory map given by file or specify 'auto'.
+    *              example: -memmap c:\\temp\\my_custom_memory_map.txt
+    *              example: -memmap auto
+    *    -pagefile[0-9] = page file(s) to use in addition to physical memory.
+    *              Normally pagefile.sys have index 0 and swapfile.sys index 1.
+    *              Page files are in constant flux - do not use if time diff
+    *              between memory dump and page files are more than few minutes.
+    *              Example: 'pagefile0 swapfile.sys'
+    *    -disable-python = prevent the python plugin sub-system from loading.
+    *    -disable-symbolserver = disable symbol server until user change.
+    *              This parameter will take precedence over registry settings.
+    *    -disable-symbols = disable symbol lookups from .pdb files.
+    *    -disable-infodb = disable the infodb and any symbol lookups via it.
+    *    -waitinitialize = Wait for initialization to complete before returning.
+    *              Normal use is that some initialization is done asynchronously
+    *              and may not be completed when initialization call is completed.
+    *              This includes virtual memory compression, registry and more.
+    *              Example: '-waitinitialize'
+    *    -userinteract = allow vmm.dll to, on the console, query the user for
+    *              information such as, but not limited to, leechcore device options.
+    *              Default: user interaction = disabled.
+    *    -vm       = virtual machine (VM) parsing.
+    *    -vm-basic = virtual machine (VM) parsing (physical memory only).
+    *    -vm-nested = virtual machine (VM) parsing (including nested VMs).
+    *    -forensic-yara-rules = perfom a forensic yara scan with specified rules.
+    *              Full path to source or compiled yara rules should be specified.
+    *              Example: -forensic-yara-rules "C:\Temp\my_yara_rules.yar"
+    *    -forensic = start a forensic scan of the physical memory immediately after
+    *              startup if possible. Allowed parameter values range from 0-4.
+    *              Note! forensic mode is not available for live memory.
+    *              1 = forensic mode with in-memory sqlite database.
+    *              2 = forensic mode with temp sqlite database deleted upon exit.
+    *              3 = forensic mode with temp sqlite database remaining upon exit.
+    *              4 = forensic mode with static named sqlite database (vmm.sqlite3).
+    *              Example -forensic 4
+    *
+    * -- argc
+    * -- argv
+    * -- ppLcErrorInfo = optional pointer to receive a function allocated memory of
+    *              struct LC_CONFIG_ERRORINFO with extended error information upon
+    *              failure. Any memory received should be free'd by caller by
+    *              calling LcMemFree().
+    * -- return = VMM_HANDLE on success for usage in subsequent API calls. NULL=fail.
+    */
+    EXPORTED_FUNCTION _Success_(return != NULL)
+        VMM_HANDLE VMMDLL_Initialize(_In_ DWORD argc, _In_ LPSTR argv[]);
+
+    EXPORTED_FUNCTION _Success_(return != NULL)
+        VMM_HANDLE VMMDLL_InitializeEx(_In_ DWORD argc, _In_ LPSTR argv[], _Out_opt_ PPLC_CONFIG_ERRORINFO ppLcErrorInfo);
+
+    /*
+    * Close an instantiated version of VMM_HANDLE and free up any resources.
+    * -- hVMM
+    */
+    EXPORTED_FUNCTION
+        VOID VMMDLL_Close(_In_opt_ _Post_ptr_invalid_ VMM_HANDLE hVMM);
+
+    /*
+    * Close all instantiated versions of VMM_HANDLE and free up all resources.
+    */
+    EXPORTED_FUNCTION
+        VOID VMMDLL_CloseAll();
+
+    /*
+    * Query the size of memory allocated by the VMMDLL.
+    * -- pvMem
+    * -- return = number of bytes required to hold memory allocation.
+    */
+    EXPORTED_FUNCTION _Success_(return != 0)
+        SIZE_T VMMDLL_MemSize(_In_ PVOID pvMem);
+
+    /*
+    * Free memory allocated by the VMMDLL.
+    * -- pvMem
+    */
+    EXPORTED_FUNCTION
+        VOID VMMDLL_MemFree(_Frees_ptr_opt_ PVOID pvMem);
+
+
+
+    //-----------------------------------------------------------------------------
+    // CONFIGURATION SETTINGS BELOW:
+    // Configure MemProcFS or the underlying memory
+    // acquisition devices.
+    //-----------------------------------------------------------------------------
+
+    /*
+    * Options used together with the functions: VMMDLL_ConfigGet & VMMDLL_ConfigSet
+    * Options are defined with either: VMMDLL_OPT_* in this header file or as
+    * LC_OPT_* in leechcore.h
+    * For more detailed information check the sources for individual device types.
+    */
+#define VMMDLL_OPT_CORE_PRINTF_ENABLE                   0x4000000100000000  // RW
+#define VMMDLL_OPT_CORE_VERBOSE                         0x4000000200000000  // RW
+#define VMMDLL_OPT_CORE_VERBOSE_EXTRA                   0x4000000300000000  // RW
+#define VMMDLL_OPT_CORE_VERBOSE_EXTRA_TLP               0x4000000400000000  // RW
+#define VMMDLL_OPT_CORE_MAX_NATIVE_ADDRESS              0x4000000800000000  // R
+#define VMMDLL_OPT_CORE_LEECHCORE_HANDLE                0x4000001000000000  // R - underlying leechcore handle (do not close).
+
+#define VMMDLL_OPT_CORE_SYSTEM                          0x2000000100000000  // R
+#define VMMDLL_OPT_CORE_MEMORYMODEL                     0x2000000200000000  // R
+
+#define VMMDLL_OPT_CONFIG_IS_REFRESH_ENABLED            0x2000000300000000  // R - 1/0
+#define VMMDLL_OPT_CONFIG_TICK_PERIOD                   0x2000000400000000  // RW - base tick period in ms
+#define VMMDLL_OPT_CONFIG_READCACHE_TICKS               0x2000000500000000  // RW - memory cache validity period (in ticks)
+#define VMMDLL_OPT_CONFIG_TLBCACHE_TICKS                0x2000000600000000  // RW - page table (tlb) cache validity period (in ticks)
+#define VMMDLL_OPT_CONFIG_PROCCACHE_TICKS_PARTIAL       0x2000000700000000  // RW - process refresh (partial) period (in ticks)
+#define VMMDLL_OPT_CONFIG_PROCCACHE_TICKS_TOTAL         0x2000000800000000  // RW - process refresh (full) period (in ticks)
+#define VMMDLL_OPT_CONFIG_VMM_VERSION_MAJOR             0x2000000900000000  // R
+#define VMMDLL_OPT_CONFIG_VMM_VERSION_MINOR             0x2000000A00000000  // R
+#define VMMDLL_OPT_CONFIG_VMM_VERSION_REVISION          0x2000000B00000000  // R
+#define VMMDLL_OPT_CONFIG_STATISTICS_FUNCTIONCALL       0x2000000C00000000  // RW - enable function call statistics (.status/statistics_fncall file)
+#define VMMDLL_OPT_CONFIG_IS_PAGING_ENABLED             0x2000000D00000000  // RW - 1/0
+#define VMMDLL_OPT_CONFIG_DEBUG                         0x2000000E00000000  // W
+#define VMMDLL_OPT_CONFIG_YARA_RULES                    0x2000000F00000000  // R
+
+#define VMMDLL_OPT_WIN_VERSION_MAJOR                    0x2000010100000000  // R
+#define VMMDLL_OPT_WIN_VERSION_MINOR                    0x2000010200000000  // R
+#define VMMDLL_OPT_WIN_VERSION_BUILD                    0x2000010300000000  // R
+#define VMMDLL_OPT_WIN_SYSTEM_UNIQUE_ID                 0x2000010400000000  // R
+
+#define VMMDLL_OPT_FORENSIC_MODE                        0x2000020100000000  // RW - enable/retrieve forensic mode type [0-4].
+
+    // REFRESH OPTIONS:
+#define VMMDLL_OPT_REFRESH_ALL                          0x2001ffff00000000  // W - refresh all caches
+#define VMMDLL_OPT_REFRESH_FREQ_MEM                     0x2001100000000000  // W - refresh memory cache (excl. TLB) [fully]
+#define VMMDLL_OPT_REFRESH_FREQ_MEM_PARTIAL             0x2001000200000000  // W - refresh memory cache (excl. TLB) [partial 33%/call]
+#define VMMDLL_OPT_REFRESH_FREQ_TLB                     0x2001080000000000  // W - refresh page table (TLB) cache [fully]
+#define VMMDLL_OPT_REFRESH_FREQ_TLB_PARTIAL             0x2001000400000000  // W - refresh page table (TLB) cache [partial 33%/call]
+#define VMMDLL_OPT_REFRESH_FREQ_FAST                    0x2001040000000000  // W - refresh fast frequency - incl. partial process refresh
+#define VMMDLL_OPT_REFRESH_FREQ_MEDIUM                  0x2001000100000000  // W - refresh medium frequency - incl. full process refresh
+#define VMMDLL_OPT_REFRESH_FREQ_SLOW                    0x2001001000000000  // W - refresh slow frequency.
+
+// PROCESS OPTIONS: [LO-DWORD: Process PID]
+#define VMMDLL_OPT_PROCESS_DTB                          0x2002000100000000  // W - force set process directory table base.
+#define VMMDLL_OPT_PROCESS_DTB_FAST_LOWINTEGRITY        0x2002000200000000  // W - force set process directory table base (fast, low integrity mode, with less checks) - use at own risk!.
+
+    static LPCSTR VMMDLL_MEMORYMODEL_TOSTRING[5] = { "N/A", "X86", "X86PAE", "X64", "ARM64" };
+
+    typedef enum tdVMMDLL_MEMORYMODEL_TP {
+        VMMDLL_MEMORYMODEL_NA = 0,
+        VMMDLL_MEMORYMODEL_X86 = 1,
+        VMMDLL_MEMORYMODEL_X86PAE = 2,
+        VMMDLL_MEMORYMODEL_X64 = 3,
+        VMMDLL_MEMORYMODEL_ARM64 = 4,
+    } VMMDLL_MEMORYMODEL_TP;
+
+    typedef enum tdVMMDLL_SYSTEM_TP {
+        VMMDLL_SYSTEM_UNKNOWN_PHYSICAL = 0,
+        VMMDLL_SYSTEM_UNKNOWN_64 = 1,
+        VMMDLL_SYSTEM_WINDOWS_64 = 2,
+        VMMDLL_SYSTEM_UNKNOWN_32 = 3,
+        VMMDLL_SYSTEM_WINDOWS_32 = 4,
+        VMMDLL_SYSTEM_UNKNOWN_X64 = 1,    // deprecated - do not use!
+        VMMDLL_SYSTEM_WINDOWS_X64 = 2,    // deprecated - do not use!
+        VMMDLL_SYSTEM_UNKNOWN_X86 = 3,    // deprecated - do not use!
+        VMMDLL_SYSTEM_WINDOWS_X86 = 4     // deprecated - do not use!
+    } VMMDLL_SYSTEM_TP;
+
+    /*
+    * Get a device specific option value. Please see defines VMMDLL_OPT_* for infor-
+    * mation about valid option values. Please note that option values may overlap
+    * between different device types with different meanings.
+    * -- hVMM
+    * -- fOption
+    * -- pqwValue = pointer to ULONG64 to receive option value.
+    * -- return = success/fail.
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_ConfigGet(_In_ VMM_HANDLE hVMM, _In_ ULONG64 fOption, _Out_ PULONG64 pqwValue);
+
+    /*
+    * Set a device specific option value. Please see defines VMMDLL_OPT_* for infor-
+    * mation about valid option values. Please note that option values may overlap
+    * between different device types with different meanings.
+    * -- hVMM
+    * -- fOption
+    * -- qwValue
+    * -- return = success/fail.
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_ConfigSet(_In_ VMM_HANDLE hVMM, _In_ ULONG64 fOption, _In_ ULONG64 qwValue);
+
+
+
+    //-----------------------------------------------------------------------------
+    // FORWARD DECLARATIONS:
+    //-----------------------------------------------------------------------------
+
+    typedef struct tdVMMDLL_MAP_PFN* PVMMDLL_MAP_PFN;
+
+
+
+    //-----------------------------------------------------------------------------
+    // LINUX SPECIFIC DEFINES:
+    //-----------------------------------------------------------------------------
+#ifdef LINUX
+
+#define IMAGE_SIZEOF_SHORT_NAME              8
+
+    typedef struct _IMAGE_DATA_DIRECTORY {
+        DWORD   VirtualAddress;
+        DWORD   Size;
+    } IMAGE_DATA_DIRECTORY, * PIMAGE_DATA_DIRECTORY;
+
+    typedef struct _IMAGE_SECTION_HEADER {
+        BYTE    Name[IMAGE_SIZEOF_SHORT_NAME];
+        union {
+            DWORD   PhysicalAddress;
+            DWORD   VirtualSize;
+        } Misc;
+        DWORD   VirtualAddress;
+        DWORD   SizeOfRawData;
+        DWORD   PointerToRawData;
+        DWORD   PointerToRelocations;
+        DWORD   PointerToLinenumbers;
+        WORD    NumberOfRelocations;
+        WORD    NumberOfLinenumbers;
+        DWORD   Characteristics;
+    } IMAGE_SECTION_HEADER, * PIMAGE_SECTION_HEADER;
+
+    typedef struct _SERVICE_STATUS {
+        DWORD   dwServiceType;
+        DWORD   dwCurrentState;
+        DWORD   dwControlsAccepted;
+        DWORD   dwWin32ExitCode;
+        DWORD   dwServiceSpecificExitCode;
+        DWORD   dwCheckPoint;
+        DWORD   dwWaitHint;
+    } SERVICE_STATUS, * LPSERVICE_STATUS;
+#endif /* LINUX */
+
+
+
+    //-----------------------------------------------------------------------------
+    // VFS - VIRTUAL FILE SYSTEM FUNCTIONALITY BELOW:
+    // NB! VFS FUNCTIONALITY REQUIRES PLUGINS TO BE INITIALIZED
+    //     WITH CALL TO VMMDLL_InitializePlugins().
+    // This is the core of MemProcFS. All implementation and analysis towards
+    // the virtual file system (vfs) is possible by using functionality below. 
+    //-----------------------------------------------------------------------------
 
 #define VMMDLL_STATUS_SUCCESS                       ((NTSTATUS)0x00000000L)
 #define VMMDLL_STATUS_UNSUCCESSFUL                  ((NTSTATUS)0xC0000001L)
@@ -173,185 +347,431 @@ BOOL VMMDLL_ConfigSet(_In_ ULONG64 fOption, _In_ ULONG64 qwValue);
 
 #define VMMDLL_VFS_FILELIST_EXINFO_VERSION          1
 #define VMMDLL_VFS_FILELIST_VERSION                 2
+#define VMMDLL_VFS_FILELISTBLOB_VERSION             0xf88f0001
 
-typedef struct tdVMMDLL_VFS_FILELIST_EXINFO {
-    DWORD dwVersion;
-    BOOL fCompressed;                   // set flag FILE_ATTRIBUTE_COMPRESSED - (no meaning but shows gui artifact in explorer.exe)
-    union {
-        FILETIME ftCreationTime;        // 0 = default time
-        QWORD qwCreationTime;
-    };
-    union {
-        FILETIME ftLastAccessTime;      // 0 = default time
-        QWORD qwLastAccessTime;
-    };
-    union {
-        FILETIME ftLastWriteTime;       // 0 = default time
-        QWORD qwLastWriteTime;
-    };
-} VMMDLL_VFS_FILELIST_EXINFO, *PVMMDLL_VFS_FILELIST_EXINFO;
+    typedef struct tdVMMDLL_VFS_FILELIST_EXINFO {
+        DWORD dwVersion;
+        BOOL fCompressed;                   // set flag FILE_ATTRIBUTE_COMPRESSED - (no meaning but shows gui artifact in explorer.exe)
+        union {
+            FILETIME ftCreationTime;        // 0 = default time
+            QWORD qwCreationTime;
+        };
+        union {
+            FILETIME ftLastAccessTime;      // 0 = default time
+            QWORD qwLastAccessTime;
+        };
+        union {
+            FILETIME ftLastWriteTime;       // 0 = default time
+            QWORD qwLastWriteTime;
+        };
+    } VMMDLL_VFS_FILELIST_EXINFO, * PVMMDLL_VFS_FILELIST_EXINFO;
 
-typedef struct tdVMMDLL_VFS_FILELIST {
-    DWORD dwVersion;
-    VOID(*pfnAddFile)     (_Inout_ HANDLE h, _In_ LPWSTR wszName, _In_ ULONG64 cb, _In_opt_ PVMMDLL_VFS_FILELIST_EXINFO pExInfo);
-    VOID(*pfnAddDirectory)(_Inout_ HANDLE h, _In_ LPWSTR wszName, _In_opt_ PVMMDLL_VFS_FILELIST_EXINFO pExInfo);
-    HANDLE h;
-} VMMDLL_VFS_FILELIST, *PVMMDLL_VFS_FILELIST;
+    typedef struct tdVMMDLL_VFS_FILELIST2 {
+        DWORD dwVersion;
+        VOID(*pfnAddFile)     (_Inout_ HANDLE h, _In_ LPSTR uszName, _In_ ULONG64 cb, _In_opt_ PVMMDLL_VFS_FILELIST_EXINFO pExInfo);
+        VOID(*pfnAddDirectory)(_Inout_ HANDLE h, _In_ LPSTR uszName, _In_opt_ PVMMDLL_VFS_FILELIST_EXINFO pExInfo);
+        HANDLE h;
+    } VMMDLL_VFS_FILELIST2, * PVMMDLL_VFS_FILELIST2;
 
-/*
-* Helper inline functions for callbacks into the VMM_VFS_FILELIST structure.
-*/
+    typedef struct tdVMMDLL_VFS_FILELISTBLOB_ENTRY {
+        ULONG64 ouszName;                       // byte offset to string from VMMDLL_VFS_FILELISTBLOB.uszMultiText
+        ULONG64 cbFileSize;                     // -1 == directory
+        VMMDLL_VFS_FILELIST_EXINFO ExInfo;      // optional ExInfo
+    } VMMDLL_VFS_FILELISTBLOB_ENTRY, * PVMMDLL_VFS_FILELISTBLOB_ENTRY;
 
-inline VOID VMMDLL_VfsList_AddFile(_In_ HANDLE pFileList, _In_ LPWSTR wszName, _In_ ULONG64 cb, _In_opt_ PVMMDLL_VFS_FILELIST_EXINFO pExInfo)
-{
-    ((PVMMDLL_VFS_FILELIST)pFileList)->pfnAddFile(((PVMMDLL_VFS_FILELIST)pFileList)->h, wszName, cb, pExInfo);
-}
+    typedef struct tdVMMDLL_VFS_FILELISTBLOB {
+        DWORD dwVersion;                        // VMMDLL_VFS_FILELISTBLOB_VERSION
+        DWORD cbStruct;
+        DWORD cFileEntry;
+        DWORD cbMultiText;
+        union {
+            LPSTR uszMultiText;
+            QWORD _Reserved;
+        };
+        DWORD _FutureUse[8];
+        VMMDLL_VFS_FILELISTBLOB_ENTRY FileEntry[0];
+    } VMMDLL_VFS_FILELISTBLOB, * PVMMDLL_VFS_FILELISTBLOB;
 
-inline VOID VMMDLL_VfsList_AddDirectory(_In_ HANDLE pFileList, _In_ LPWSTR wszName, _In_opt_ PVMMDLL_VFS_FILELIST_EXINFO pExInfo)
-{
-    ((PVMMDLL_VFS_FILELIST)pFileList)->pfnAddDirectory(((PVMMDLL_VFS_FILELIST)pFileList)->h, wszName, pExInfo);
-}
+    /*
+    * Helper functions for callbacks into the VMM_VFS_FILELIST2 structure.
+    */
+    EXPORTED_FUNCTION
+        VOID VMMDLL_VfsList_AddFile(_In_ HANDLE pFileList, _In_ LPSTR uszName, _In_ ULONG64 cb, _In_opt_ PVMMDLL_VFS_FILELIST_EXINFO pExInfo);
+    VOID VMMDLL_VfsList_AddFileW(_In_ HANDLE pFileList, _In_ LPWSTR wszName, _In_ ULONG64 cb, _In_opt_ PVMMDLL_VFS_FILELIST_EXINFO pExInfo);
+    EXPORTED_FUNCTION
+        VOID VMMDLL_VfsList_AddDirectory(_In_ HANDLE pFileList, _In_ LPSTR uszName, _In_opt_ PVMMDLL_VFS_FILELIST_EXINFO pExInfo);
+    VOID VMMDLL_VfsList_AddDirectoryW(_In_ HANDLE pFileList, _In_ LPWSTR wszName, _In_opt_ PVMMDLL_VFS_FILELIST_EXINFO pExInfo);
+    EXPORTED_FUNCTION BOOL VMMDLL_VfsList_IsHandleValid(_In_ HANDLE pFileList);
 
-inline BOOL VMMDLL_VfsList_IsHandleValid(_In_ HANDLE pFileList)
-{
-    return ((PVMMDLL_VFS_FILELIST)pFileList)->dwVersion == VMMDLL_VFS_FILELIST_VERSION;
-}
+    /*
+    * List a directory of files in MemProcFS. Directories and files will be listed
+    * by callbacks into functions supplied in the pFileList parameter.
+    * If information of an individual file is needed it's neccessary to list all
+    * files in its directory.
+    * -- hVMM
+    * -- [uw]szPath
+    * -- pFileList
+    * -- return
+    */
+    EXPORTED_FUNCTION
+        _Success_(return) BOOL VMMDLL_VfsListU(_In_ VMM_HANDLE hVMM, _In_ LPSTR  uszPath, _Inout_ PVMMDLL_VFS_FILELIST2 pFileList);
+    _Success_(return) BOOL VMMDLL_VfsListW(_In_ VMM_HANDLE hVMM, _In_ LPWSTR wszPath, _Inout_ PVMMDLL_VFS_FILELIST2 pFileList);
 
-/*
-* List a directory of files in the memory process file system. Directories and
-* files will be listed by callbacks into functions supplied in the pFileList
-* parameter. If information of an individual file is needed it's neccessary
-* to list all files in its directory.
-* -- wcsPath
-* -- pFileList
-* -- return
-*/
-_Success_(return)
-BOOL VMMDLL_VfsList(_In_ LPCWSTR wcsPath, _Inout_ PVMMDLL_VFS_FILELIST pFileList);
+    /*
+    * List a directory of files in MemProcFS and return a VMMDLL_VFS_FILELISTBLOB.
+    * CALLER FREE: VMMDLL_MemFree(return)
+    * -- hVMM
+    * -- uszPath
+    * -- return
+    */
+    EXPORTED_FUNCTION
+        _Success_(return != NULL) PVMMDLL_VFS_FILELISTBLOB VMMDLL_VfsListBlobU(_In_ VMM_HANDLE hVMM, _In_ LPSTR uszPath);
 
-/*
-* Read select parts of a file in the memory process file system.
-* -- wcsFileName
-* -- pb
-* -- cb
-* -- pcbRead
-* -- cbOffset
-* -- return
-*
-*/
-NTSTATUS VMMDLL_VfsRead(_In_ LPCWSTR wcsFileName, _Out_ LPVOID pb, _In_ DWORD cb, _Out_ PDWORD pcbRead, _In_ ULONG64 cbOffset);
+    /*
+    * Read select parts of a file in MemProcFS.
+    * -- hVMM
+    * -- [uw]szFileName
+    * -- pb
+    * -- cb
+    * -- pcbRead
+    * -- cbOffset
+    * -- return
+    *
+    */
+    EXPORTED_FUNCTION
+        NTSTATUS VMMDLL_VfsReadU(_In_ VMM_HANDLE hVMM, _In_ LPSTR  uszFileName, _Out_writes_to_(cb, *pcbRead) PBYTE pb, _In_ DWORD cb, _Out_ PDWORD pcbRead, _In_ ULONG64 cbOffset);
+    NTSTATUS VMMDLL_VfsReadW(_In_ VMM_HANDLE hVMM, _In_ LPWSTR wszFileName, _Out_writes_to_(cb, *pcbRead) PBYTE pb, _In_ DWORD cb, _Out_ PDWORD pcbRead, _In_ ULONG64 cbOffset);
 
-/*
-* Write select parts to a file in the memory process file system.
-* -- wcsFileName
-* -- pb
-* -- cb
-* -- pcbWrite
-* -- cbOffset
-* -- return
-*/
-NTSTATUS VMMDLL_VfsWrite(_In_ LPCWSTR wcsFileName, _In_ LPVOID pb, _In_ DWORD cb, _Out_ PDWORD pcbWrite, _In_ ULONG64 cbOffset);
+    /*
+    * Write select parts to a file in MemProcFS.
+    * -- hVMM
+    * -- [uw]szFileName
+    * -- pb
+    * -- cb
+    * -- pcbWrite
+    * -- cbOffset
+    * -- return
+    */
+    EXPORTED_FUNCTION
+        NTSTATUS VMMDLL_VfsWriteU(_In_ VMM_HANDLE hVMM, _In_ LPSTR  uszFileName, _In_reads_(cb) PBYTE pb, _In_ DWORD cb, _Out_ PDWORD pcbWrite, _In_ ULONG64 cbOffset);
+    NTSTATUS VMMDLL_VfsWriteW(_In_ VMM_HANDLE hVMM, _In_ LPWSTR wszFileName, _In_reads_(cb) PBYTE pb, _In_ DWORD cb, _Out_ PDWORD pcbWrite, _In_ ULONG64 cbOffset);
 
-/*
-* Utility functions for memory process file system read/write towards different
-* underlying data representations.
-*/
-NTSTATUS VMMDLL_UtilVfsReadFile_FromPBYTE(_In_ PBYTE pbFile, _In_ ULONG64 cbFile, _Out_ PBYTE pb, _In_ DWORD cb, _Out_ PDWORD pcbRead, _In_ ULONG64 cbOffset);
-NTSTATUS VMMDLL_UtilVfsReadFile_FromQWORD(_In_ ULONG64 qwValue, _Out_ PBYTE pb, _In_ DWORD cb, _Out_ PDWORD pcbRead, _In_ ULONG64 cbOffset, _In_ BOOL fPrefix);
-NTSTATUS VMMDLL_UtilVfsReadFile_FromDWORD(_In_ DWORD dwValue, _Out_ PBYTE pb, _In_ DWORD cb, _Out_ PDWORD pcbRead, _In_ ULONG64 cbOffset, _In_ BOOL fPrefix);
-NTSTATUS VMMDLL_UtilVfsReadFile_FromBOOL(_In_ BOOL fValue, _Out_ PBYTE pb, _In_ DWORD cb, _Out_ PDWORD pcbRead, _In_ ULONG64 cbOffset);
-NTSTATUS VMMDLL_UtilVfsWriteFile_BOOL(_Inout_ PBOOL pfTarget, _In_ PBYTE pb, _In_ DWORD cb, _Out_ PDWORD pcbWrite, _In_ ULONG64 cbOffset);
-NTSTATUS VMMDLL_UtilVfsWriteFile_DWORD(_Inout_ PDWORD pdwTarget, _In_ PBYTE pb, _In_ DWORD cb, _Out_ PDWORD pcbWrite, _In_ ULONG64 cbOffset, _In_ DWORD dwMinAllow);
+    /*
+    * Utility functions for MemProcFS read/write towards different underlying data
+    * representations.
+    */
+    EXPORTED_FUNCTION NTSTATUS VMMDLL_UtilVfsReadFile_FromPBYTE(_In_ PBYTE pbFile, _In_ ULONG64 cbFile, _Out_writes_to_(cb, *pcbRead) PBYTE pb, _In_ DWORD cb, _Out_ PDWORD pcbRead, _In_ ULONG64 cbOffset);
+    EXPORTED_FUNCTION NTSTATUS VMMDLL_UtilVfsReadFile_FromQWORD(_In_ ULONG64 qwValue, _Out_writes_to_(cb, *pcbRead) PBYTE pb, _In_ DWORD cb, _Out_ PDWORD pcbRead, _In_ ULONG64 cbOffset, _In_ BOOL fPrefix);
+    EXPORTED_FUNCTION NTSTATUS VMMDLL_UtilVfsReadFile_FromDWORD(_In_ DWORD dwValue, _Out_writes_to_(cb, *pcbRead) PBYTE pb, _In_ DWORD cb, _Out_ PDWORD pcbRead, _In_ ULONG64 cbOffset, _In_ BOOL fPrefix);
+    EXPORTED_FUNCTION NTSTATUS VMMDLL_UtilVfsReadFile_FromBOOL(_In_ BOOL fValue, _Out_writes_to_(cb, *pcbRead) PBYTE pb, _In_ DWORD cb, _Out_ PDWORD pcbRead, _In_ ULONG64 cbOffset);
+    EXPORTED_FUNCTION NTSTATUS VMMDLL_UtilVfsWriteFile_BOOL(_Inout_ PBOOL pfTarget, _In_reads_(cb) PBYTE pb, _In_ DWORD cb, _Out_ PDWORD pcbWrite, _In_ ULONG64 cbOffset);
+    EXPORTED_FUNCTION NTSTATUS VMMDLL_UtilVfsWriteFile_DWORD(_Inout_ PDWORD pdwTarget, _In_reads_(cb) PBYTE pb, _In_ DWORD cb, _Out_ PDWORD pcbWrite, _In_ ULONG64 cbOffset, _In_ DWORD dwMinAllow);
 
 
-//-----------------------------------------------------------------------------
-// PLUGIN MANAGER FUNCTIONALITY BELOW:
-// Function and structures to initialize and use the memory process file system
-// plugin functionality. The plugin manager is started by a call to function:
-// VMM_VfsInitializePlugins. Each built-in plugin and external plugin of which
-// the DLL name matches m_*.dll will receive a call to its InitializeVmmPlugin
-// function. The plugin/module may decide to call pfnPluginManager_Register to
-// register plugins in the form of different names one or more times.
-// Example of registration function in a plugin DLL below: 
-// 'VOID InitializeVmmPlugin(_In_ PVMM_PLUGIN_REGINFO pRegInfo)'
-//-----------------------------------------------------------------------------
 
-/*
-* Initialize all potential plugins, both built-in and external, that maps into
-* the memory process file system. Please note that plugins are not loaded by
-* default - they have to be explicitly loaded by calling this function. They
-* will be unloaded on a general close of the vmm dll.
-* -- return
-*/
-_Success_(return)
-BOOL VMMDLL_VfsInitializePlugins();
+    //-----------------------------------------------------------------------------
+    // PLUGIN MANAGER FUNCTIONALITY BELOW:
+    // Function and structures to initialize and use MemProcFS plugin functionality.
+    // The plugin manager is started by a call to function:
+    // VMM_VfsInitializePlugins. Each built-in plugin and external plugin of which
+    // the DLL name matches m_*.dll will receive a call to its InitializeVmmPlugin
+    // function. The plugin/module may decide to call pfnPluginManager_Register to
+    // register plugins in the form of different names one or more times.
+    // Example of registration function in a plugin DLL below: 
+    // 'VOID InitializeVmmPlugin(_In_ VMM_HANDLE H, _In_ PVMM_PLUGIN_REGINFO pRegInfo)'
+    //-----------------------------------------------------------------------------
+
+    /*
+    * Initialize all potential plugins, both built-in and external, that maps into
+    * MemProcFS. Please note that plugins are not loaded by default - they have to
+    * be explicitly loaded by calling this function. They will be unloaded on a
+    * general close of the vmm dll.
+    * -- hVMM
+    * -- return
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_InitializePlugins(_In_ VMM_HANDLE hVMM);
 
 #define VMMDLL_PLUGIN_CONTEXT_MAGIC                 0xc0ffee663df9301c
-#define VMMDLL_PLUGIN_CONTEXT_VERSION               3
+#define VMMDLL_PLUGIN_CONTEXT_VERSION               5
 #define VMMDLL_PLUGIN_REGINFO_MAGIC                 0xc0ffee663df9301d
-#define VMMDLL_PLUGIN_REGINFO_VERSION               5
+#define VMMDLL_PLUGIN_REGINFO_VERSION               18
+#define VMMDLL_FORENSIC_JSONDATA_VERSION            0xc0ee0002
+#define VMMDLL_FORENSIC_INGEST_VIRTMEM_VERSION      0xc0dd0001
+#define VMMDLL_FORENSIC_INGEST_OBJECT_VERSION       0xc0de0001
 
-#define VMMDLL_PLUGIN_EVENT_VERBOSITYCHANGE         0x01
-#define VMMDLL_PLUGIN_EVENT_REFRESH_PROCESS_TOTAL   0x02
-#define VMMDLL_PLUGIN_EVENT_REFRESH_REGISTRY        0x04
+#define VMMDLL_PLUGIN_NOTIFY_VERBOSITYCHANGE        0x01
+#define VMMDLL_PLUGIN_NOTIFY_REFRESH_FAST           0x05    // refresh fast event   - at partial process refresh.
+#define VMMDLL_PLUGIN_NOTIFY_REFRESH_MEDIUM         0x02    // refresh medium event - at full process refresh.
+#define VMMDLL_PLUGIN_NOTIFY_REFRESH_SLOW           0x04    // refresh slow event   - at registry refresh.
 
-typedef struct tdVMMDLL_PLUGIN_CONTEXT {
-    ULONG64 magic;
-    WORD wVersion;
-    WORD wSize;
-    DWORD dwPID;
-    PVOID pProcess;
-    LPWSTR wszModule;
-    LPWSTR wszPath;
-    PVOID pvReserved1;
-    PVOID pvReserved2;
-} VMMDLL_PLUGIN_CONTEXT, *PVMMDLL_PLUGIN_CONTEXT;
+#define VMMDLL_PLUGIN_NOTIFY_FORENSIC_INIT          0x01000100
+#define VMMDLL_PLUGIN_NOTIFY_FORENSIC_INIT_COMPLETE 0x01000200
+#define VMMDLL_PLUGIN_NOTIFY_VM_ATTACH_DETACH       0x01000400
 
-typedef struct tdVMMDLL_PLUGIN_REGINFO {
-    ULONG64 magic;
-    WORD wVersion;
-    WORD wSize;
-    VMMDLL_MEMORYMODEL_TP tpMemoryModel;
-    VMMDLL_SYSTEM_TP tpSystem;
-    HMODULE hDLL;
-    HMODULE hReservedDllPython3X;   // not for general use (only used for python).
-    BOOL(*pfnPluginManager_Register)(struct tdVMMDLL_PLUGIN_REGINFO *pPluginRegInfo);
-    HMODULE hReservedDllPython3;    // not for general use (only used for python).
-    PVOID pvReserved2;
-    // general plugin registration info to be filled out by the plugin below:
-    struct {
-        WCHAR wszPathName[128];
-        BOOL fRootModule;
-        BOOL fProcessModule;
-        PVOID pvReserved[2];
-    } reg_info;
-    // function plugin registration info to be filled out by the plugin below:
-    struct {
-        BOOL(*pfnList)(_In_ PVMMDLL_PLUGIN_CONTEXT ctx, _Inout_ PHANDLE pFileList);
-        NTSTATUS(*pfnRead)(_In_ PVMMDLL_PLUGIN_CONTEXT ctx, _Out_ PBYTE pb, _In_ DWORD cb, _Out_ PDWORD pcbRead,  _In_ ULONG64 cbOffset);
-        NTSTATUS(*pfnWrite)(_In_ PVMMDLL_PLUGIN_CONTEXT ctx, _In_ PBYTE pb, _In_ DWORD cb, _Out_ PDWORD pcbWrite, _In_ ULONG64 cbOffset);
-        VOID(*pfnNotify)(_In_ DWORD fEvent, _In_opt_ PVOID pvEvent, _In_opt_ DWORD cbEvent);
-        VOID(*pfnClose)();
-        PVOID pvReserved[16];
-    } reg_fn;
-} VMMDLL_PLUGIN_REGINFO, *PVMMDLL_PLUGIN_REGINFO;
+    typedef DWORD                                       VMMDLL_MODULE_ID;
+    typedef HANDLE* PVMMDLL_PLUGIN_INTERNAL_CONTEXT;
+    typedef struct tdVMMDLL_CSV_HANDLE* VMMDLL_CSV_HANDLE;
 
-//-----------------------------------------------------------------------------
-// VMM CORE FUNCTIONALITY BELOW:
-// Vmm core functaionlity such as read (and write) to both virtual and physical
-// memory. NB! writing will only work if the target is supported - i.e. not a
-// memory dump file...
-// To read physical memory specify dwPID as (DWORD)-1
-//-----------------------------------------------------------------------------
+#define VMMDLL_MID_MAIN                             ((VMMDLL_MODULE_ID)0x80000001)
+#define VMMDLL_MID_PYTHON                           ((VMMDLL_MODULE_ID)0x80000002)
+#define VMMDLL_MID_DEBUG                            ((VMMDLL_MODULE_ID)0x80000003)
+#define VMMDLL_MID_RUST                             ((VMMDLL_MODULE_ID)0x80000004)
+
+    typedef struct tdVMMDLL_PLUGIN_CONTEXT {
+        ULONG64 magic;
+        WORD wVersion;
+        WORD wSize;
+        DWORD dwPID;
+        PVOID pProcess;
+        LPSTR uszModule;
+        LPSTR uszPath;
+        PVOID pvReserved1;
+        PVMMDLL_PLUGIN_INTERNAL_CONTEXT ctxM;       // optional internal module context.
+        VMMDLL_MODULE_ID MID;
+    } VMMDLL_PLUGIN_CONTEXT, * PVMMDLL_PLUGIN_CONTEXT;
+
+    typedef struct tdVMMDLL_FORENSIC_JSONDATA {
+        DWORD dwVersion;        // must equal VMMDLL_FORENSIC_JSONDATA_VERSION
+        DWORD _FutureUse;
+        LPSTR szjType;          // log type/name (json encoded)
+        DWORD i;
+        DWORD dwPID;
+        QWORD vaObj;
+        BOOL fva[2];            // log va even if zero
+        QWORD va[2];
+        BOOL fNum[2];           // log num even if zero
+        QWORD qwNum[2];
+        BOOL fHex[2];           // log hex even if zero
+        QWORD qwHex[2];
+        // str: will be prioritized in order: szu > wsz.
+        LPCSTR usz[2];          // str: utf-8 encoded
+        LPCWSTR wsz[2];         // str: wide
+        BYTE _Reserved[0x4000 + 256];
+    } VMMDLL_FORENSIC_JSONDATA, * PVMMDLL_FORENSIC_JSONDATA;
+
+    typedef enum tdVMMDLL_FORENSIC_INGEST_OBJECT_TYPE {
+        VMMDLL_FORENSIC_INGEST_OBJECT_TYPE_FILE = 1,
+    } VMMDLL_FORENSIC_INGEST_OBJECT_TYPE;
+
+    typedef struct tdVMMDLL_FORENSIC_INGEST_OBJECT {
+        OPAQUE_OB_HEADER _Reserved;
+        DWORD dwVersion;        // must equal VMMDLL_FORENSIC_INGEST_OBJECT_VERSION
+        VMMDLL_FORENSIC_INGEST_OBJECT_TYPE tp;
+        QWORD vaObject;
+        LPSTR uszText;
+        PBYTE pb;
+        DWORD cb;
+        DWORD cbReadActual;     // actual bytes read (may be spread out in pb)
+    } VMMDLL_FORENSIC_INGEST_OBJECT, * PVMMDLL_FORENSIC_INGEST_OBJECT;
+
+    typedef struct tdVMMDLL_FORENSIC_INGEST_PHYSMEM {
+        BOOL fValid;
+        QWORD pa;
+        DWORD cb;
+        PBYTE pb;
+        DWORD cMEMs;
+        PPMEM_SCATTER ppMEMs;
+        PVMMDLL_MAP_PFN pPfnMap;
+    } VMMDLL_FORENSIC_INGEST_PHYSMEM, * PVMMDLL_FORENSIC_INGEST_PHYSMEM;
+
+    typedef struct tdVMMDLL_FORENSIC_INGEST_VIRTMEM {
+        OPAQUE_OB_HEADER _Reserved;
+        DWORD dwVersion;        // must equal VMMDLL_FORENSIC_INGEST_VIRTMEM_VERSION
+        BOOL fPte;
+        BOOL fVad;
+        PVOID pvProcess;
+        DWORD dwPID;
+        QWORD va;
+        PBYTE pb;
+        DWORD cb;
+        DWORD cbReadActual;     // actual bytes read (may be spread out in pb)
+    } VMMDLL_FORENSIC_INGEST_VIRTMEM, * PVMMDLL_FORENSIC_INGEST_VIRTMEM;
+
+    typedef struct tdVMMDLL_PLUGIN_REGINFO {
+        ULONG64 magic;                          // VMMDLL_PLUGIN_REGINFO_MAGIC
+        WORD wVersion;                          // VMMDLL_PLUGIN_REGINFO_VERSION
+        WORD wSize;                             // size of struct
+        VMMDLL_MEMORYMODEL_TP tpMemoryModel;
+        VMMDLL_SYSTEM_TP tpSystem;
+        HMODULE hDLL;
+        BOOL(*pfnPluginManager_Register)(_In_ VMM_HANDLE H, struct tdVMMDLL_PLUGIN_REGINFO* pPluginRegInfo);
+        LPSTR uszPathVmmDLL;
+        DWORD _Reserved[30];
+        // python plugin information - not for general use
+        struct {
+            BOOL fPythonStandalone;
+            DWORD _Reserved;
+            HMODULE hReservedDllPython3;
+            HMODULE hReservedDllPython3X;
+        } python;
+        // general plugin registration info to be filled out by the plugin below:
+        struct {
+            PVMMDLL_PLUGIN_INTERNAL_CONTEXT ctxM;   // optional internal module context [must be cleaned by pfnClose() call].
+            CHAR uszPathName[128];
+            BOOL fRootModule;
+            BOOL fProcessModule;
+            BOOL fRootModuleHidden;
+            BOOL fProcessModuleHidden;
+            CHAR sTimelineNameShort[6];
+            CHAR _Reserved[2];
+            CHAR uszTimelineFile[32];
+            CHAR _Reserved2[32];
+        } reg_info;
+        // function plugin registration info to be filled out by the plugin below:
+        struct {
+            BOOL(*pfnList)(_In_ VMM_HANDLE H, _In_ PVMMDLL_PLUGIN_CONTEXT ctxP, _Inout_ PHANDLE pFileList);
+            NTSTATUS(*pfnRead)(_In_ VMM_HANDLE H, _In_ PVMMDLL_PLUGIN_CONTEXT ctxP, _Out_writes_to_(cb, *pcbRead) PBYTE pb, _In_ DWORD cb, _Out_ PDWORD pcbRead, _In_ ULONG64 cbOffset);
+            NTSTATUS(*pfnWrite)(_In_ VMM_HANDLE H, _In_ PVMMDLL_PLUGIN_CONTEXT ctxP, _In_reads_(cb) PBYTE pb, _In_ DWORD cb, _Out_ PDWORD pcbWrite, _In_ ULONG64 cbOffset);
+            VOID(*pfnNotify)(_In_ VMM_HANDLE H, _In_ PVMMDLL_PLUGIN_CONTEXT ctxP, _In_ DWORD fEvent, _In_opt_ PVOID pvEvent, _In_opt_ DWORD cbEvent);
+            VOID(*pfnClose)(_In_ VMM_HANDLE H, _In_ PVMMDLL_PLUGIN_CONTEXT ctxP);
+            BOOL(*pfnVisibleModule)(_In_ VMM_HANDLE H, _In_ PVMMDLL_PLUGIN_CONTEXT ctxP);
+            PVOID pvReserved[10];
+        } reg_fn;
+        // Optional forensic plugin functionality for forensic (more comprehensive)
+        // analysis of various data. Functions are optional.
+        // Functions are called in the below order and way.
+        // 1: pfnInitialize()            - multi-threaded (between plugins).
+        // 2: (multiple types see below) - multi-threaded (between plugins).
+        //    pfnLogCSV()
+        //    pfnLogJSON()
+        //    pfnFindEvil()
+        //    pfnIngestPhysmem()
+        //    pfnIngestVirtmem()
+        // 3. pfnIngestFinalize()        - single-threaded. (pfnLogCSV/pfnLogJSON/pfnFindEvil may still be active).
+        // 4. pfnTimeline()              - single-threaded. (pfnLogCSV/pfnLogJSON/pfnFindEvil may still be active).
+        // 5. pfnFinalize()              - single-threaded.
+        struct {
+            PVOID(*pfnInitialize)(_In_ VMM_HANDLE H, _In_ PVMMDLL_PLUGIN_CONTEXT ctxP);
+            VOID(*pfnFinalize)(_In_ VMM_HANDLE H, _In_opt_ PVOID ctxfc);
+            VOID(*pfnTimeline)(
+                _In_ VMM_HANDLE H,
+                _In_opt_ PVOID ctxfc,
+                _In_ HANDLE hTimeline,
+                _In_ VOID(*pfnAddEntry)(_In_ VMM_HANDLE H, _In_ HANDLE hTimeline, _In_ QWORD ft, _In_ DWORD dwAction, _In_ DWORD dwPID, _In_ DWORD dwData32, _In_ QWORD qwData64, _In_ LPSTR uszText),
+                _In_ VOID(*pfnEntryAddBySql)(_In_ VMM_HANDLE H, _In_ HANDLE hTimeline, _In_ DWORD cEntrySql, _In_ LPSTR* pszEntrySql));
+            VOID(*pfnIngestObject)(_In_ VMM_HANDLE H, _In_opt_ PVOID ctxfc, _In_ PVMMDLL_FORENSIC_INGEST_OBJECT pIngestObject);
+            VOID(*pfnIngestPhysmem)(_In_ VMM_HANDLE H, _In_opt_ PVOID ctxfc, _In_ PVMMDLL_FORENSIC_INGEST_PHYSMEM pIngestPhysmem);
+            VOID(*pfnIngestVirtmem)(_In_ VMM_HANDLE H, _In_opt_ PVOID ctxfc, _In_ PVMMDLL_FORENSIC_INGEST_VIRTMEM pIngestVirtmem);
+            VOID(*pfnIngestFinalize)(_In_ VMM_HANDLE H, _In_opt_ PVOID ctxfc);
+            VOID(*pfnFindEvil)(_In_ VMM_HANDLE H, _In_ VMMDLL_MODULE_ID MID, _In_opt_ PVOID ctxfc);
+            PVOID pvReserved[6];
+            VOID(*pfnLogCSV)(_In_ VMM_HANDLE H, _In_ PVMMDLL_PLUGIN_CONTEXT ctxP, _In_ VMMDLL_CSV_HANDLE hCSV);
+            VOID(*pfnLogJSON)(_In_ VMM_HANDLE H, _In_ PVMMDLL_PLUGIN_CONTEXT ctxP, _In_ VOID(*pfnLogJSON)(_In_ VMM_HANDLE H, _In_ PVMMDLL_FORENSIC_JSONDATA pData));
+        } reg_fnfc;
+        // Additional system information - read/only by the plugins.
+        struct {
+            BOOL f32;
+            DWORD dwVersionMajor;
+            DWORD dwVersionMinor;
+            DWORD dwVersionBuild;
+            DWORD _Reserved[32];
+        } sysinfo;
+    } VMMDLL_PLUGIN_REGINFO, * PVMMDLL_PLUGIN_REGINFO;
+
+
+
+    //-----------------------------------------------------------------------------
+    // FORENSIC-MODE SPECIFIC FUNCTIONALITY BELOW:
+    //-----------------------------------------------------------------------------
+
+    /*
+    * Append text data to a memory-backed forensics file.
+    * All text should be UTF-8 encoded.
+    * -- H
+    * -- uszFileName
+    * -- uszFormat
+    * -- ..
+    * -- return = number of bytes appended (excluding terminating null).
+    */
+    EXPORTED_FUNCTION _Success_(return != 0)
+        SIZE_T VMMDLL_ForensicFileAppend(
+            _In_ VMM_HANDLE H,
+            _In_ LPSTR uszFileName,
+            _In_z_ _Printf_format_string_ LPSTR uszFormat,
+            ...
+        );
+
+
+
+    //-----------------------------------------------------------------------------
+    // VMM LOG FUNCTIONALITY BELOW:
+    // It's possible for external code (primarily external plugins) to make use of
+    // the MemProcFS logging system.
+    // ----------------------------------------------------------------------------
+
+    typedef enum tdVMMDLL_LOGLEVEL {
+        VMMDLL_LOGLEVEL_CRITICAL = 1,  // critical stopping error
+        VMMDLL_LOGLEVEL_WARNING = 2,  // severe warning error
+        VMMDLL_LOGLEVEL_INFO = 3,  // normal/info message
+        VMMDLL_LOGLEVEL_VERBOSE = 4,  // verbose message (visible with -v)
+        VMMDLL_LOGLEVEL_DEBUG = 5,  // debug message (visible with -vv)
+        VMMDLL_LOGLEVEL_TRACE = 6,  // trace message
+        VMMDLL_LOGLEVEL_NONE = 7,  // do not use!
+    } VMMDLL_LOGLEVEL;
+
+    /*
+    * Log a message using the internal MemProcFS vmm logging system. Log messages
+    * will be displayed/suppressed depending on current logging configuration.
+    * -- hVMM
+    * -- MID = module id supplied by plugin context PVMMDLL_PLUGIN_CONTEXT or
+    *          id given by VMMDLL_MID_*.
+    * -- dwLogLevel
+    * -- uszFormat
+    * -- ...
+    */
+    EXPORTED_FUNCTION
+        VOID VMMDLL_Log(
+            _In_ VMM_HANDLE hVMM,
+            _In_opt_ VMMDLL_MODULE_ID MID,
+            _In_ VMMDLL_LOGLEVEL dwLogLevel,
+            _In_z_ _Printf_format_string_ LPSTR uszFormat,
+            ...
+        );
+
+    /*
+    * Log a message using the internal MemProcFS vmm logging system. Log messages
+    * will be displayed/suppressed depending on current logging configuration.
+    * -- hVMM
+    * -- MID = module id supplied by plugin context PVMMDLL_PLUGIN_CONTEXT or
+    *          id given by VMMDLL_MID_*.
+    * -- dwLogLevel
+    * -- uszFormat
+    * -- arglist
+    */
+    EXPORTED_FUNCTION
+        VOID VMMDLL_LogEx(
+            _In_ VMM_HANDLE hVMM,
+            _In_opt_ VMMDLL_MODULE_ID MID,
+            _In_ VMMDLL_LOGLEVEL dwLogLevel,
+            _In_z_ _Printf_format_string_ LPSTR uszFormat,
+            va_list arglist
+        );
+
+
+
+    //-----------------------------------------------------------------------------
+    // VMM CORE FUNCTIONALITY BELOW:
+    // Vmm core functaionlity such as read (and write) to both virtual and physical
+    // memory. NB! writing will only work if the target is supported - i.e. not a
+    // memory dump file...
+    // To read physical memory specify dwPID as (DWORD)-1
+    //-----------------------------------------------------------------------------
+
+#define VMMDLL_PID_PROCESS_WITH_KERNELMEMORY        0x80000000      // Combine with dwPID to enable process kernel memory (NB! use with extreme care).
 
 // FLAG used to supress the default read cache in calls to VMM_MemReadEx()
 // which will lead to the read being fetched from the target system always.
 // Cached page tables (used for translating virtual2physical) are still used.
-#define VMMDLL_FLAG_NOCACHE                        0x0001  // do not use the data cache (force reading from memory acquisition device)
-#define VMMDLL_FLAG_ZEROPAD_ON_FAIL                0x0002  // zero pad failed physical memory reads and report success if read within range of physical memory.
-#define VMMDLL_FLAG_FORCECACHE_READ                0x0008  // force use of cache - fail non-cached pages - only valid for reads, invalid with VMM_FLAG_NOCACHE/VMM_FLAG_ZEROPAD_ON_FAIL.
-#define VMMDLL_FLAG_NOPAGING                       0x0010  // do not try to retrieve memory from paged out memory from pagefile/compressed (even if possible)
-#define VMMDLL_FLAG_NOPAGING_IO                    0x0020  // do not try to retrieve memory from paged out memory if read would incur additional I/O (even if possible).
+#define VMMDLL_FLAG_NOCACHE                         0x0001  // do not use the data cache (force reading from memory acquisition device)
+#define VMMDLL_FLAG_ZEROPAD_ON_FAIL                 0x0002  // zero pad failed physical memory reads and report success if read within range of physical memory.
+#define VMMDLL_FLAG_FORCECACHE_READ                 0x0008  // force use of cache - fail non-cached pages - only valid for reads, invalid with VMM_FLAG_NOCACHE/VMM_FLAG_ZEROPAD_ON_FAIL.
+#define VMMDLL_FLAG_NOPAGING                        0x0010  // do not try to retrieve memory from paged out memory from pagefile/compressed (even if possible)
+#define VMMDLL_FLAG_NOPAGING_IO                     0x0020  // do not try to retrieve memory from paged out memory if read would incur additional I/O (even if possible).
+#define VMMDLL_FLAG_NOCACHEPUT                      0x0100  // do not write back to the data cache upon successful read from memory acquisition device.
+#define VMMDLL_FLAG_CACHE_RECENT_ONLY               0x0200  // only fetch from the most recent active cache region when reading.
+#define VMMDLL_FLAG_NO_PREDICTIVE_READ              0x0400  // do not perform additional predictive page reads (default on smaller requests).
+#define VMMDLL_FLAG_FORCECACHE_READ_DISABLE         0x0800  // disable/override any use of VMM_FLAG_FORCECACHE_READ. only recommended for local files. improves forensic artifact order.
 
 /*
 * Read memory in various non-contigious locations specified by the pointers to
@@ -360,920 +780,2085 @@ typedef struct tdVMMDLL_PLUGIN_REGINFO {
 * boost will be given if above hardware limit. Max size of each unit of work is
 * one 4k page (4096 bytes). Reads must not cross 4k page boundaries. Reads must
 * start at even DWORDs (4-bytes).
+* -- hVMM
 * -- dwPID - PID of target process, (DWORD)-1 to read physical memory.
 * -- ppMEMs = array of scatter read headers.
 * -- cpMEMs = count of ppMEMs.
 * -- flags = optional flags as given by VMMDLL_FLAG_*
 * -- return = the number of successfully read items.
 */
-DWORD VMMDLL_MemReadScatter(_In_ DWORD dwPID, _Inout_ PPMEM_IO_SCATTER_HEADER ppMEMs, _In_ DWORD cpMEMs, _In_ DWORD flags);
+    EXPORTED_FUNCTION
+        DWORD VMMDLL_MemReadScatter(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _Inout_ PPMEM_SCATTER ppMEMs, _In_ DWORD cpMEMs, _In_ DWORD flags);
 
-/*
-* Read a single 4096-byte page of memory.
-* -- dwPID - PID of target process, (DWORD)-1 to read physical memory.
-* -- qwA
-* -- pbPage
-* -- return = success/fail (depending if all requested bytes are read or not).
-*/
-_Success_(return)
-BOOL VMMDLL_MemReadPage(_In_ DWORD dwPID, _In_ ULONG64 qwA, _Inout_bytecount_(4096) PBYTE pbPage);
+    /*
+    * Write memory in various non-contigious locations specified by the pointers to
+    * the items in the ppMEMs array. Result for each unit of work will be given
+    * individually. No upper limit of number of items to write Max size of each
+    * unit of work is one 4k page (4096 bytes). Writes must not cross 4k page boundaries.
+    * -- hVMM
+    * -- dwPID - PID of target process, (DWORD)-1 to write physical memory.
+    * -- ppMEMs = array of scatter read headers.
+    * -- cpMEMs = count of ppMEMs.
+    * -- return = the number of hopefully successfully written items.
+    */
+    EXPORTED_FUNCTION
+        DWORD VMMDLL_MemWriteScatter(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _Inout_ PPMEM_SCATTER ppMEMs, _In_ DWORD cpMEMs);
 
-/*
-* Read a contigious arbitrary amount of memory.
-* -- dwPID - PID of target process, (DWORD)-1 to read physical memory.
-* -- qwA
-* -- pb
-* -- cb
-* -- return = success/fail (depending if all requested bytes are read or not).
-*/
-_Success_(return)
-BOOL VMMDLL_MemRead(_In_ DWORD dwPID, _In_ ULONG64 qwA, _Out_writes_(cb) PBYTE pb, _In_ DWORD cb);
+    /*
+    * Read a single 4096-byte page of memory.
+    * -- hVMM
+    * -- dwPID - PID of target process, (DWORD)-1 to read physical memory.
+    * -- qwA
+    * -- pbPage
+    * -- return = success/fail (depending if all requested bytes are read or not).
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_MemReadPage(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_ ULONG64 qwA, _Inout_bytecount_(4096) PBYTE pbPage);
 
-/*
-* Read a contigious amount of memory and report the number of bytes read in pcbRead.
-* -- dwPID - PID of target process, (DWORD)-1 to read physical memory.
-* -- qwA
-* -- pb
-* -- cb
-* -- pcbRead
-* -- flags = flags as in VMMDLL_FLAG_*
-* -- return = success/fail. NB! reads may report as success even if 0 bytes are
-*        read - it's recommended to verify pcbReadOpt parameter.
-*/
-_Success_(return)
-BOOL VMMDLL_MemReadEx(_In_ DWORD dwPID, _In_ ULONG64 qwA, _Out_writes_(cb) PBYTE pb, _In_ DWORD cb, _Out_opt_ PDWORD pcbReadOpt, _In_ ULONG64 flags);
+    /*
+    * Read a contigious arbitrary amount of memory.
+    * -- hVMM
+    * -- dwPID - PID of target process, (DWORD)-1 to read physical memory.
+    * -- qwA
+    * -- pb
+    * -- cb
+    * -- return = success/fail (depending if all requested bytes are read or not).
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_MemRead(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_ ULONG64 qwA, _Out_writes_(cb) PBYTE pb, _In_ DWORD cb);
 
-/*
-* Prefetch a number of addresses (specified in the pA array) into the memory
-* cache. This function is to be used to batch larger known reads into local
-* cache before making multiple smaller reads - which will then happen from
-* the cache. Function exists for performance reasons.
-* -- dwPID = PID of target process, (DWORD)-1 for physical memory.
-* -- pPrefetchAddresses = array of addresses to read into cache.
-* -- cPrefetchAddresses
-*/
-_Success_(return)
-BOOL VMMDLL_MemPrefetchPages(_In_ DWORD dwPID, _In_reads_(cPrefetchAddresses) PULONG64 pPrefetchAddresses, _In_ DWORD cPrefetchAddresses);
+    /*
+    * Read a contigious amount of memory and report the number of bytes read in pcbRead.
+    * -- hVMM
+    * -- dwPID - PID of target process, (DWORD)-1 to read physical memory.
+    * -- qwA
+    * -- pb
+    * -- cb
+    * -- pcbRead
+    * -- flags = flags as in VMMDLL_FLAG_*
+    * -- return = success/fail. NB! reads may report as success even if 0 bytes are
+    *        read - it's recommended to verify pcbReadOpt parameter.
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_MemReadEx(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_ ULONG64 qwA, _Out_writes_(cb) PBYTE pb, _In_ DWORD cb, _Out_opt_ PDWORD pcbReadOpt, _In_ ULONG64 flags);
 
-/*
-* Write a contigious arbitrary amount of memory. Please note some virtual memory
-* such as pages of executables (such as DLLs) may be shared between different
-* virtual memory over different processes. As an example a write to kernel32.dll
-* in one process is likely to affect kernel32 in the whole system - in all
-* processes. Heaps and Stacks and other memory are usually safe to write to.
-* Please take care when writing to memory!
-* -- dwPID = PID of target process, (DWORD)-1 to read physical memory.
-* -- qwA
-* -- pb
-* -- cb
-* -- return = TRUE on success, FALSE on partial or zero write.
-*/
-_Success_(return)
-BOOL VMMDLL_MemWrite(_In_ DWORD dwPID, _In_ ULONG64 qwA, _In_reads_(cb) PBYTE pb, _In_ DWORD cb);
+    /*
+    * Prefetch a number of addresses (specified in the pA array) into the memory
+    * cache. This function is to be used to batch larger known reads into local
+    * cache before making multiple smaller reads - which will then happen from
+    * the cache. Function exists for performance reasons.
+    * -- hVMM
+    * -- dwPID = PID of target process, (DWORD)-1 for physical memory.
+    * -- pPrefetchAddresses = array of addresses to read into cache.
+    * -- cPrefetchAddresses
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_MemPrefetchPages(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_reads_(cPrefetchAddresses) PULONG64 pPrefetchAddresses, _In_ DWORD cPrefetchAddresses);
 
-/*
-* Translate a virtual address to a physical address by walking the page tables
-* of the specified process.
-* -- dwPID
-* -- qwVA
-* -- pqwPA
-* -- return = success/fail.
-*/
-_Success_(return)
-BOOL VMMDLL_MemVirt2Phys(_In_ DWORD dwPID, _In_ ULONG64 qwVA, _Out_ PULONG64 pqwPA);
+    /*
+    * Write a contigious arbitrary amount of memory. Please note some virtual memory
+    * such as pages of executables (such as DLLs) may be shared between different
+    * virtual memory over different processes. As an example a write to kernel32.dll
+    * in one process is likely to affect kernel32 in the whole system - in all
+    * processes. Heaps and Stacks and other memory are usually safe to write to.
+    * Please take care when writing to memory!
+    * -- hVMM
+    * -- dwPID = PID of target process, (DWORD)-1 to read physical memory.
+    * -- qwA
+    * -- pb
+    * -- cb
+    * -- return = TRUE on success, FALSE on partial or zero write.
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_MemWrite(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_ ULONG64 qwA, _In_reads_(cb) PBYTE pb, _In_ DWORD cb);
+
+    /*
+    * Translate a virtual address to a physical address by walking the page tables
+    * of the specified process.
+    * -- hVMM
+    * -- dwPID
+    * -- qwVA
+    * -- pqwPA
+    * -- return = success/fail.
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_MemVirt2Phys(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_ ULONG64 qwVA, _Out_ PULONG64 pqwPA);
 
 
 
-//-----------------------------------------------------------------------------
-// VMM PROCESS MAP FUNCTIONALITY BELOW:
-// Functionality for retrieving process related collections of items such as
-// page table map (PTE), virtual address descriptor map (VAD), loaded modules,
-// heaps and threads.
-//-----------------------------------------------------------------------------
+    //-----------------------------------------------------------------------------
+    // SIMPLIFIED EASIER TO USE READ SCATTER MEMORY FUNCTIONALITY BELOW:
+    // The flow is as following:
+    // 1. Call VMMDLL_Scatter_Initialize to initialize handle.
+    // 2. Populate memory ranges with multiple calls to VMMDLL_Scatter_Prepare
+    //    and/or VMMDLL_Scatter_PrepareEx functions. The memory buffer given to
+    //    VMMDLL_Scatter_PrepareEx will be populated with contents in step (3).
+    // 3. Retrieve the memory by calling VMMDLL_Scatter_Execute function.
+    // 4. If VMMDLL_Scatter_Prepare was used (i.e. not VMMDLL_Scatter_PrepareEx)
+    //    then retrieve the memory read in (3).
+    // 5. Clear the handle for reuse by calling VMMDLL_Scatter_Clear alternatively
+    //    Close the handle to free resources with VMMDLL_Scatter_CloseHandle.
+    // NB! buffers given to VMMDLL_Scatter_PrepareEx must not be free'd before
+    //     handle is closed since it may be used internally.
+    // NB! VMMDLL_Scatter_ExecuteRead may be called at a later point in time to
+    //     update (re-read) previously read data.
+    // NB! larger reads (up to 1 GB max) are supported but not recommended.
+    //-----------------------------------------------------------------------------
+    typedef HANDLE      VMMDLL_SCATTER_HANDLE;
 
-#define VMMDLL_MAP_PTE_VERSION              1
-#define VMMDLL_MAP_VAD_VERSION              3
-#define VMMDLL_MAP_MODULE_VERSION           1
-#define VMMDLL_MAP_HEAP_VERSION             1
-#define VMMDLL_MAP_THREAD_VERSION           1
-#define VMMDLL_MAP_HANDLE_VERSION           1
-#define VMMDLL_MAP_PHYSMEM_VERSION          1
-#define VMMDLL_MAP_USER_VERSION             1
+    /*
+    * Initialize a scatter handle which is used to call VMMDLL_Scatter_* functions.
+    * CALLER CLOSE: VMMDLL_Scatter_CloseHandle(return)
+    * -- hVMM
+    * -- dwPID - PID of target process, (DWORD)-1 to read physical memory.
+    * -- flags = optional flags as given by VMMDLL_FLAG_*
+    * -- return = handle to be used in VMMDLL_Scatter_* functions.
+    */
+    EXPORTED_FUNCTION _Success_(return != NULL)
+        VMMDLL_SCATTER_HANDLE VMMDLL_Scatter_Initialize(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_ DWORD flags);
+
+    /*
+    * Prepare (add) a memory range for reading. The memory may after a call to
+    * VMMDLL_Scatter_Execute*() be retrieved with VMMDLL_Scatter_Read().
+    * -- hS
+    * -- va = start address of the memory range to read.
+    * -- cb = size of memory range to read.
+    * -- return
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_Scatter_Prepare(_In_ VMMDLL_SCATTER_HANDLE hS, _In_ QWORD va, _In_ DWORD cb);
+
+    /*
+    * Prepare (add) a memory range for reading. The buffer pb and the read length
+    * *pcbRead will be populated when VMMDLL_Scatter_Execute*() is later called.
+    * NB! the buffer pb must not be deallocated before VMMDLL_Scatter_CloseHandle()
+    *     has been called since it's used internally by the scatter functionality!
+    * -- hS
+    * -- va = start address of the memory range to read.
+    * -- cb = size of memory range to read.
+    * -- pb = buffer to populate with read memory when calling VMMDLL_Scatter_ExecuteRead()
+    * -- pcbRead = optional pointer to be populated with number of bytes successfully read.
+    * -- return
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_Scatter_PrepareEx(_In_ VMMDLL_SCATTER_HANDLE hS, _In_ QWORD va, _In_ DWORD cb, _Out_writes_opt_(cb) PBYTE pb, _Out_opt_ PDWORD pcbRead);
+
+    /*
+    * Prepare (add) a memory range for writing.
+    * The memory contents to write is processed when calling this function.
+    * Any changes to va/pb/cb after this call will not be reflected in the write.
+    * The memory is later written when calling VMMDLL_Scatter_Execute().
+    * Writing takes place before reading.
+    * -- hS
+    * -- va = start address of the memory range to write.
+    * -- pb = data to write.
+    * -- cb = size of memory range to write.
+    * -- return
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_Scatter_PrepareWrite(_In_ VMMDLL_SCATTER_HANDLE hS, _In_ QWORD va, _In_reads_(cb) PBYTE pb, _In_ DWORD cb);
+
+    /*
+    * Prepare (add) a memory range for writing.
+    * Memory contents to write is processed when calling VMMDLL_Scatter_Execute().
+    * The buffer pb must be valid when VMMDLL_Scatter_Execute() is called.
+    * The memory is later written when calling VMMDLL_Scatter_Execute().
+    * Writing takes place before reading.
+    * -- hS
+    * -- va = start address of the memory range to write.
+    * -- pb = data to write. Buffer must be valid when VMMDLL_Scatter_Execute() is called.
+    * -- cb = size of memory range to write.
+    * -- return
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_Scatter_PrepareWriteEx(_In_ VMMDLL_SCATTER_HANDLE hS, _In_ QWORD va, _In_reads_(cb) PBYTE pb, _In_ DWORD cb);
+
+    /*
+    * Retrieve and Write memory previously populated.
+    * Write any memory prepared with VMMDLL_Scatter_PrepareWrite function (1st).
+    * Retrieve the memory ranges previously populated with calls to the
+    * VMMDLL_Scatter_Prepare* functions (2nd).
+    * -- hS
+    * -- return
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_Scatter_Execute(_In_ VMMDLL_SCATTER_HANDLE hS);
+
+    /*
+    * Retrieve the memory ranges previously populated with calls to the
+    * VMMDLL_Scatter_Prepare* functions.
+    * -- hS
+    * -- return
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_Scatter_ExecuteRead(_In_ VMMDLL_SCATTER_HANDLE hS);
+
+    /*
+    * Read out memory in previously populated ranges. This function should only be
+    * called after the memory has been retrieved using VMMDLL_Scatter_ExecuteRead().
+    * -- hS
+    * -- va
+    * -- cb
+    * -- pb
+    * -- pcbRead
+    * -- return
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_Scatter_Read(_In_ VMMDLL_SCATTER_HANDLE hS, _In_ QWORD va, _In_ DWORD cb, _Out_writes_opt_(cb) PBYTE pb, _Out_opt_ PDWORD pcbRead);
+
+    /*
+    * Clear/Reset the handle for use in another subsequent read scatter operation.
+    * -- hS = the scatter handle to clear for reuse.
+    * -- dwPID = optional PID change.
+    * -- flags
+    * -- return
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_Scatter_Clear(_In_ VMMDLL_SCATTER_HANDLE hS, _In_opt_ DWORD dwPID, _In_ DWORD flags);
+
+    /*
+    * Close the scatter handle and free the resources it uses.
+    * -- hS = the scatter handle to close.
+    */
+    EXPORTED_FUNCTION
+        VOID VMMDLL_Scatter_CloseHandle(_In_opt_ _Post_ptr_invalid_ VMMDLL_SCATTER_HANDLE hS);
+
+
+
+    //-----------------------------------------------------------------------------
+    // VMM PROCESS MAP FUNCTIONALITY BELOW:
+    // Functionality for retrieving process related collections of items such as
+    // page table map (PTE), virtual address descriptor map (VAD), loaded modules,
+    // heaps and threads.
+    //-----------------------------------------------------------------------------
+
+#define VMMDLL_MAP_PTE_VERSION              2
+#define VMMDLL_MAP_VAD_VERSION              6
+#define VMMDLL_MAP_VADEX_VERSION            4
+#define VMMDLL_MAP_MODULE_VERSION           6
+#define VMMDLL_MAP_UNLOADEDMODULE_VERSION   2
+#define VMMDLL_MAP_EAT_VERSION              3
+#define VMMDLL_MAP_IAT_VERSION              2
+#define VMMDLL_MAP_HEAP_VERSION             4
+#define VMMDLL_MAP_HEAPALLOC_VERSION        1
+#define VMMDLL_MAP_THREAD_VERSION           4
+#define VMMDLL_MAP_HANDLE_VERSION           3
+#define VMMDLL_MAP_POOL_VERSION             2
+#define VMMDLL_MAP_NET_VERSION              3
+#define VMMDLL_MAP_PHYSMEM_VERSION          2
+#define VMMDLL_MAP_USER_VERSION             2
+#define VMMDLL_MAP_VM_VERSION               2
+#define VMMDLL_MAP_SERVICE_VERSION          3
 
 // flags to check for existence in the fPage field of VMMDLL_MAP_PTEENTRY
-#define VMMDLL_MEMMAP_FLAG_PAGE_W          0x0000000000000002
-#define VMMDLL_MEMMAP_FLAG_PAGE_NS         0x0000000000000004
-#define VMMDLL_MEMMAP_FLAG_PAGE_NX         0x8000000000000000
-#define VMMDLL_MEMMAP_FLAG_PAGE_MASK       0x8000000000000006
+#define VMMDLL_MEMMAP_FLAG_PAGE_W           0x0000000000000002
+#define VMMDLL_MEMMAP_FLAG_PAGE_NS          0x0000000000000004
+#define VMMDLL_MEMMAP_FLAG_PAGE_NX          0x8000000000000000
+#define VMMDLL_MEMMAP_FLAG_PAGE_MASK        0x8000000000000006
 
-typedef struct tdVMMDLL_MAP_PTEENTRY {
-    QWORD vaBase;
-    QWORD cPages;
-    QWORD fPage;
-    BOOL  fWoW64;
-    DWORD cwszText;
-    LPWSTR wszText;
-    DWORD _Reserved1[2];
-} VMMDLL_MAP_PTEENTRY, *PVMMDLL_MAP_PTEENTRY;
+#define VMMDLL_POOLMAP_FLAG_ALL             0
+#define VMMDLL_POOLMAP_FLAG_BIG             1
 
-typedef struct tdVMMDLL_MAP_VADENTRY {
-    QWORD vaStart;
-    QWORD vaEnd;
-    QWORD vaVad;
-    // DWORD 0
-    DWORD VadType           : 3;   // Pos 0
-    DWORD Protection        : 5;   // Pos 3
-    DWORD fImage            : 1;   // Pos 8
-    DWORD fFile             : 1;   // Pos 9
-    DWORD fPageFile         : 1;   // Pos 10
-    DWORD fPrivateMemory    : 1;   // Pos 11
-    DWORD fTeb              : 1;   // Pos 12
-    DWORD fStack            : 1;   // Pos 13
-    DWORD fSpare            : 2;   // Pos 14
-    DWORD HeapNum           : 7;   // Pos 16
-    DWORD fHeap             : 1;   // Pos 23
-    DWORD cwszDescription   : 8;   // Pos 24
-    // DWORD 1
-    DWORD CommitCharge      : 31;   // Pos 0
-    DWORD MemCommit         : 1;    // Pos 31
-    DWORD u2;
-    DWORD cbPrototypePte;
-    QWORD vaPrototypePte;
-    QWORD vaSubsection;
-    LPWSTR wszText;                 // optional LPWSTR pointed into VMMDLL_MAP_VAD.wszMultiText
-    DWORD cwszText;                 // WCHAR count not including terminating null
-    DWORD _Reserved;
-    QWORD vaFileObject;             // only valid if fFile/fImage _and_ after wszText is initialized
-} VMMDLL_MAP_VADENTRY, *PVMMDLL_MAP_VADENTRY;
+#define VMMDLL_MODULE_FLAG_NORMAL           0
+#define VMMDLL_MODULE_FLAG_DEBUGINFO        1
+#define VMMDLL_MODULE_FLAG_VERSIONINFO      2
 
-typedef struct tdVMMDLL_MAP_MODULEENTRY {
-    QWORD vaBase;
-    QWORD vaEntry;
-    DWORD cbImageSize;
-    BOOL  fWoW64;
-    LPWSTR wszText;
-    DWORD cwszText;                 // wchar count not including terminating null
-    DWORD _Reserved1[7];
-} VMMDLL_MAP_MODULEENTRY, *PVMMDLL_MAP_MODULEENTRY;
+    typedef enum tdVMMDLL_PTE_TP {
+        VMMDLL_PTE_TP_NA = 0,
+        VMMDLL_PTE_TP_HARDWARE = 1,
+        VMMDLL_PTE_TP_TRANSITION = 2,
+        VMMDLL_PTE_TP_PROTOTYPE = 3,
+        VMMDLL_PTE_TP_DEMANDZERO = 4,
+        VMMDLL_PTE_TP_COMPRESSED = 5,
+        VMMDLL_PTE_TP_PAGEFILE = 6,
+        VMMDLL_PTE_TP_FILE = 7,
+    } VMMDLL_PTE_TP, * PVMMDLL_PTE_TP;
 
-typedef struct tdVMMDLL_MAP_HEAPENTRY {
-    QWORD vaHeapSegment;
-    DWORD cPages;
-    DWORD cPagesUnCommitted : 24;
-    DWORD HeapId : 7;
-    DWORD fPrimary : 1;
-} VMMDLL_MAP_HEAPENTRY, *PVMMDLL_MAP_HEAPENTRY;
+    typedef struct tdVMMDLL_MAP_PTEENTRY {
+        QWORD vaBase;
+        QWORD cPages;
+        QWORD fPage;
+        BOOL  fWoW64;
+        DWORD _FutureUse1;
+        union { LPSTR  uszText; LPWSTR wszText; };              // U/W dependant
+        DWORD _Reserved1;
+        DWORD cSoftware;    // # software (non active) PTEs in region
+    } VMMDLL_MAP_PTEENTRY, * PVMMDLL_MAP_PTEENTRY;
 
-typedef struct tdVMMDLL_MAP_THREADENTRY {
-    DWORD dwTID;
-    DWORD dwPID;
-    DWORD dwExitStatus;
-    UCHAR bState;
-    UCHAR bRunning;
-    UCHAR bPriority;
-    UCHAR bBasePriority;
-    QWORD vaETHREAD;
-    QWORD vaTeb;
-    QWORD ftCreateTime;
-    QWORD ftExitTime;
-    QWORD vaStartAddress;
-    QWORD vaStackBaseUser;
-    QWORD vaStackLimitUser;
-    QWORD vaStackBaseKernel;
-    QWORD vaStackLimitKernel;
-    DWORD _FutureUse[10];
-} VMMDLL_MAP_THREADENTRY, *PVMMDLL_MAP_THREADENTRY;
+    typedef struct tdVMMDLL_MAP_VADENTRY {
+        QWORD vaStart;
+        QWORD vaEnd;
+        QWORD vaVad;
+        // DWORD 0
+        DWORD VadType : 3;   // Pos 0
+        DWORD Protection : 5;   // Pos 3
+        DWORD fImage : 1;   // Pos 8
+        DWORD fFile : 1;   // Pos 9
+        DWORD fPageFile : 1;   // Pos 10
+        DWORD fPrivateMemory : 1;   // Pos 11
+        DWORD fTeb : 1;   // Pos 12
+        DWORD fStack : 1;   // Pos 13
+        DWORD fSpare : 2;   // Pos 14
+        DWORD HeapNum : 7;   // Pos 16
+        DWORD fHeap : 1;   // Pos 23
+        DWORD cwszDescription : 8;   // Pos 24
+        // DWORD 1
+        DWORD CommitCharge : 31;   // Pos 0
+        DWORD MemCommit : 1;    // Pos 31
+        DWORD u2;
+        DWORD cbPrototypePte;
+        QWORD vaPrototypePte;
+        QWORD vaSubsection;
+        union { LPSTR  uszText; LPWSTR wszText; };              // U/W dependant
+        DWORD _FutureUse1;
+        DWORD _Reserved1;
+        QWORD vaFileObject;             // only valid if fFile/fImage _and_ after wszText is initialized
+        DWORD cVadExPages;              // number of "valid" VadEx pages in this VAD.
+        DWORD cVadExPagesBase;          // number of "valid" VadEx pages in "previous" VADs
+        QWORD _Reserved2;
+    } VMMDLL_MAP_VADENTRY, * PVMMDLL_MAP_VADENTRY;
 
-typedef struct tdVMMDLL_MAP_HANDLEENTRY {
-    QWORD vaObject;
-    DWORD dwHandle;
-    DWORD dwGrantedAccess : 24;
-    DWORD iType : 8;
-    QWORD qwHandleCount;
-    QWORD qwPointerCount;
-    QWORD vaObjectCreateInfo;
-    QWORD vaSecurityDescriptor;
-    LPWSTR wszText;
-    DWORD cwszText;
-    DWORD dwPID;
-    DWORD dwPoolTag;
-    DWORD _FutureUse[4];
-    DWORD cwszType;
-    LPWSTR wszType;
-} VMMDLL_MAP_HANDLEENTRY, *PVMMDLL_MAP_HANDLEENTRY;
+#define VMMDLL_VADEXENTRY_FLAG_HARDWARE     0x01
+#define VMMDLL_VADEXENTRY_FLAG_W            0x10
+#define VMMDLL_VADEXENTRY_FLAG_K            0x40
+#define VMMDLL_VADEXENTRY_FLAG_NX           0x80
 
-typedef struct tdVMMDLL_MAP_PHYSMEMENTRY {
-    QWORD pa;
-    QWORD cb;
-} VMMDLL_MAP_PHYSMEMENTRY, *PVMMDLL_MAP_PHYSMEMENTRY;
+    typedef struct tdVMMDLL_MAP_VADEXENTRY {
+        VMMDLL_PTE_TP tp;
+        BYTE iPML;
+        BYTE pteFlags;
+        WORD _Reserved2;
+        QWORD va;
+        QWORD pa;
+        QWORD pte;
+        struct {
+            DWORD _Reserved1;
+            VMMDLL_PTE_TP tp;
+            QWORD pa;
+            QWORD pte;
+        } proto;
+        QWORD vaVadBase;
+    } VMMDLL_MAP_VADEXENTRY, * PVMMDLL_MAP_VADEXENTRY;
 
-typedef struct tdVMMDLL_MAP_USERENTRY {
-    DWORD cwszText;                 // WCHAR count not including terminating null
-    LPWSTR wszText;                 // LPWSTR pointed into VMMOB_MAP_USER.wszMultiText
-    ULONG64 vaRegHive;
-    CHAR szSID[MAX_PATH];
-    DWORD _FutureUse[9];
-} VMMDLL_MAP_USERENTRY, *PVMMDLL_MAP_USERENTRY;
+    typedef enum tdVMMDLL_MODULE_TP {
+        VMMDLL_MODULE_TP_NORMAL = 0,
+        VMMDLL_MODULE_TP_DATA = 1,
+        VMMDLL_MODULE_TP_NOTLINKED = 2,
+        VMMDLL_MODULE_TP_INJECTED = 3,
+    } VMMDLL_MODULE_TP;
 
-typedef struct tdVMMDLL_MAP_PTE {
-    DWORD dwVersion;
-    DWORD _Reserved1[5];
-    LPWSTR wszMultiText;            // NULL or multi-wstr pointed into by VMMDLL_MAP_VADENTRY.wszText
-    DWORD cbMultiText;
-    DWORD cMap;                     // # map entries.
-    VMMDLL_MAP_PTEENTRY pMap[];     // map entries.
-} VMMDLL_MAP_PTE, *PVMMDLL_MAP_PTE;
+    typedef struct tdVMMDLL_MAP_MODULEENTRY_DEBUGINFO {
+        DWORD dwAge;
+        DWORD _Reserved;
+        BYTE Guid[16];
+        union { LPSTR  uszGuid;             LPWSTR wszGuid; };
+        union { LPSTR  uszPdbFilename;      LPWSTR wszPdbFilename; };
+    } VMMDLL_MAP_MODULEENTRY_DEBUGINFO, * PVMMDLL_MAP_MODULEENTRY_DEBUGINFO;
 
-typedef struct tdVMMDLL_MAP_VAD {
-    DWORD dwVersion;
-    DWORD _Reserved1[5];
-    LPWSTR wszMultiText;            // NULL or multi-wstr pointed into by VMMDLL_MAP_VADENTRY.wszText
-    DWORD cbMultiText;
-    DWORD cMap;                     // # map entries.
-    VMMDLL_MAP_VADENTRY pMap[];     // map entries.
-} VMMDLL_MAP_VAD, *PVMMDLL_MAP_VAD;
+    typedef struct tdVMMDLL_MAP_MODULEENTRY_VERSIONINFO {
+        union { LPSTR  uszCompanyName;      LPWSTR wszCompanyName; };
+        union { LPSTR  uszFileDescription;  LPWSTR wszFileDescription; };
+        union { LPSTR  uszFileVersion;      LPWSTR wszFileVersion; };
+        union { LPSTR  uszInternalName;     LPWSTR wszInternalName; };
+        union { LPSTR  uszLegalCopyright;   LPWSTR wszLegalCopyright; };
+        union { LPSTR  uszOriginalFilename; LPWSTR wszFileOriginalFilename; };
+        union { LPSTR  uszProductName;      LPWSTR wszProductName; };
+        union { LPSTR  uszProductVersion;   LPWSTR wszProductVersion; };
+    } VMMDLL_MAP_MODULEENTRY_VERSIONINFO, * PVMMDLL_MAP_MODULEENTRY_VERSIONINFO;
 
-typedef struct tdVMMDLL_MAP_MODULE {
-    DWORD dwVersion;
-    DWORD _Reserved1[5];
-    LPWSTR wszMultiText;            // multi-wstr pointed into by VMMDLL_MAP_MODULEENTRY.wszText
-    DWORD cbMultiText;
-    DWORD cMap;                     // # map entries.
-    VMMDLL_MAP_MODULEENTRY pMap[];  // map entries.
-} VMMDLL_MAP_MODULE, *PVMMDLL_MAP_MODULE; 
+    typedef struct tdVMMDLL_MAP_MODULEENTRY {
+        QWORD vaBase;
+        QWORD vaEntry;
+        DWORD cbImageSize;
+        BOOL  fWoW64;
+        union { LPSTR  uszText; LPWSTR wszText; };              // U/W dependant
+        DWORD _Reserved3;
+        DWORD _Reserved4;
+        union { LPSTR  uszFullName; LPWSTR wszFullName; };      // U/W dependant
+        VMMDLL_MODULE_TP tp;
+        DWORD cbFileSizeRaw;
+        DWORD cSection;
+        DWORD cEAT;
+        DWORD cIAT;
+        DWORD _Reserved2;
+        QWORD _Reserved1[3];
+        PVMMDLL_MAP_MODULEENTRY_DEBUGINFO pExDebugInfo;         // not included by default - use VMMDLL_MODULE_FLAG_DEBUGINFO to include.
+        PVMMDLL_MAP_MODULEENTRY_VERSIONINFO pExVersionInfo;     // not included by default - use VMMDLL_MODULE_FLAG_VERSIONINFO to include.
+    } VMMDLL_MAP_MODULEENTRY, * PVMMDLL_MAP_MODULEENTRY;
 
-typedef struct tdVMMDLL_MAP_HEAP {
-    DWORD dwVersion;
-    DWORD _Reserved1[8];
-    DWORD cMap;                     // # map entries.
-    VMMDLL_MAP_HEAPENTRY pMap[];    // map entries.
-} VMMDLL_MAP_HEAP, *PVMMDLL_MAP_HEAP;
+    typedef struct tdVMMDLL_MAP_UNLOADEDMODULEENTRY {
+        QWORD vaBase;
+        DWORD cbImageSize;
+        BOOL  fWoW64;
+        union { LPSTR  uszText; LPWSTR wszText; };              // U/W dependant
+        DWORD _FutureUse1;
+        DWORD dwCheckSum;               // user-mode only
+        DWORD dwTimeDateStamp;          // user-mode only
+        DWORD _Reserved1;
+        QWORD ftUnload;                 // kernel-mode only
+    } VMMDLL_MAP_UNLOADEDMODULEENTRY, * PVMMDLL_MAP_UNLOADEDMODULEENTRY;
 
-typedef struct tdVMMDLL_MAP_THREAD {
-    DWORD dwVersion;
-    DWORD _Reserved[8];
-    DWORD cMap;                     // # map entries.
-    VMMDLL_MAP_THREADENTRY pMap[];  // map entries.
-} VMMDLL_MAP_THREAD, *PVMMDLL_MAP_THREAD;
+    typedef struct tdVMMDLL_MAP_EATENTRY {
+        QWORD vaFunction;
+        DWORD dwOrdinal;
+        DWORD oFunctionsArray;          // PIMAGE_EXPORT_DIRECTORY->AddressOfFunctions[oFunctionsArray]
+        DWORD oNamesArray;              // PIMAGE_EXPORT_DIRECTORY->AddressOfNames[oNamesArray]
+        DWORD _FutureUse1;
+        union { LPSTR  uszFunction; LPWSTR wszFunction; };      // U/W dependant
+        union { LPSTR  uszForwardedFunction; LPWSTR wszForwardedFunction; };    // U/W dependant (function or ordinal name if exists).
+    } VMMDLL_MAP_EATENTRY, * PVMMDLL_MAP_EATENTRY;
 
-typedef struct tdVMMDLL_MAP_HANDLE {
-    DWORD dwVersion;
-    DWORD _Reserved1[5];
-    LPWSTR wszMultiText;            // multi-wstr pointed into by VMMDLL_MAP_HANDLEENTRY.wszText
-    DWORD cbMultiText;
-    DWORD cMap;                     // # map entries.
-    VMMDLL_MAP_HANDLEENTRY pMap[];  // map entries.
-} VMMDLL_MAP_HANDLE, *PVMMDLL_MAP_HANDLE;
+    typedef struct tdVMMDLL_MAP_IATENTRY {
+        QWORD vaFunction;
+        union { LPSTR  uszFunction; LPWSTR wszFunction; };      // U/W dependant
+        DWORD _FutureUse1;
+        DWORD _FutureUse2;
+        union { LPSTR  uszModule; LPWSTR wszModule; };          // U/W dependant
+        struct {
+            BOOL f32;
+            WORD wHint;
+            WORD _Reserved1;
+            DWORD rvaFirstThunk;
+            DWORD rvaOriginalFirstThunk;
+            DWORD rvaNameModule;
+            DWORD rvaNameFunction;
+        } Thunk;
+    } VMMDLL_MAP_IATENTRY, * PVMMDLL_MAP_IATENTRY;
 
-typedef struct tdVMMDLL_MAP_PHYSMEM {
-    DWORD dwVersion;
-    DWORD _Reserved1[5];
-    DWORD cMap;                     // # map entries.
-    VMMDLL_MAP_PHYSMEMENTRY pMap[]; // map entries.
-} VMMDLL_MAP_PHYSMEM, *PVMMDLL_MAP_PHYSMEM;
+    typedef enum tdVMMDLL_HEAP_TP {
+        VMMDLL_HEAP_TP_NA = 0,
+        VMMDLL_HEAP_TP_NT = 1,
+        VMMDLL_HEAP_TP_SEG = 2,
+    } VMMDLL_HEAP_TP, * PVMMDLL_HEAP_TP;
 
-typedef struct tdVMMDLL_MAP_USER {
-    DWORD dwVersion;
-    DWORD _Reserved1[5];
-    LPWSTR wszMultiText;            // multi-wstr pointed into by VMMDLL_MAP_HANDLEENTRY.wszText
-    DWORD cbMultiText;
-    DWORD cMap;                     // # map entries.
-    VMMDLL_MAP_USERENTRY pMap[];    // map entries.
-} VMMDLL_MAP_USER, *PVMMDLL_MAP_USER;
+    typedef enum tdVMMDLL_HEAP_SEGMENT_TP {
+        VMMDLL_HEAP_SEGMENT_TP_NA = 0,
+        VMMDLL_HEAP_SEGMENT_TP_NT_SEGMENT = 1,
+        VMMDLL_HEAP_SEGMENT_TP_NT_LFH = 2,
+        VMMDLL_HEAP_SEGMENT_TP_NT_LARGE = 3,
+        VMMDLL_HEAP_SEGMENT_TP_NT_NA = 4,
+        VMMDLL_HEAP_SEGMENT_TP_SEG_HEAP = 5,
+        VMMDLL_HEAP_SEGMENT_TP_SEG_SEGMENT = 6,
+        VMMDLL_HEAP_SEGMENT_TP_SEG_LARGE = 7,
+        VMMDLL_HEAP_SEGMENT_TP_SEG_NA = 8,
+    } VMMDLL_HEAP_SEGMENT_TP, * PVMMDLL_HEAP_SEGMENT_TP;
+
+    typedef struct tdVMMDLL_MAP_HEAP_SEGMENTENTRY {
+        QWORD va;
+        DWORD cb;
+        VMMDLL_HEAP_SEGMENT_TP tp : 16;
+        DWORD iHeap : 16;
+    } VMMDLL_MAP_HEAP_SEGMENTENTRY, * PVMMDLL_MAP_HEAP_SEGMENTENTRY;
+
+    typedef struct tdVMMDLL_MAP_HEAPENTRY {
+        QWORD va;
+        VMMDLL_HEAP_TP tp;
+        BOOL f32;
+        DWORD iHeap;
+        DWORD dwHeapNum;
+    } VMMDLL_MAP_HEAPENTRY, * PVMMDLL_MAP_HEAPENTRY;
+
+    typedef enum tdVMMDLL_HEAPALLOC_TP {
+        VMMDLL_HEAPALLOC_TP_NA = 0,
+        VMMDLL_HEAPALLOC_TP_NT_HEAP = 1,
+        VMMDLL_HEAPALLOC_TP_NT_LFH = 2,
+        VMMDLL_HEAPALLOC_TP_NT_LARGE = 3,
+        VMMDLL_HEAPALLOC_TP_NT_NA = 4,
+        VMMDLL_HEAPALLOC_TP_SEG_VS = 5,
+        VMMDLL_HEAPALLOC_TP_SEG_LFH = 6,
+        VMMDLL_HEAPALLOC_TP_SEG_LARGE = 7,
+        VMMDLL_HEAPALLOC_TP_SEG_NA = 8,
+    } VMMDLL_HEAPALLOC_TP, * PVMMDLL_HEAPALLOC_TP;
+
+    typedef struct tdVMMDLL_MAP_HEAPALLOCENTRY {
+        QWORD va;
+        DWORD cb;
+        VMMDLL_HEAPALLOC_TP tp;
+    } VMMDLL_MAP_HEAPALLOCENTRY, * PVMMDLL_MAP_HEAPALLOCENTRY;
+
+    typedef struct tdVMMDLL_MAP_THREADENTRY {
+        DWORD dwTID;
+        DWORD dwPID;
+        DWORD dwExitStatus;
+        UCHAR bState;
+        UCHAR bRunning;
+        UCHAR bPriority;
+        UCHAR bBasePriority;
+        QWORD vaETHREAD;
+        QWORD vaTeb;
+        QWORD ftCreateTime;
+        QWORD ftExitTime;
+        QWORD vaStartAddress;
+        QWORD vaStackBaseUser;          // value from _NT_TIB / _TEB
+        QWORD vaStackLimitUser;         // value from _NT_TIB / _TEB
+        QWORD vaStackBaseKernel;
+        QWORD vaStackLimitKernel;
+        QWORD vaTrapFrame;
+        QWORD vaRIP;                    // RIP register (if user mode)
+        QWORD vaRSP;                    // RSP register (if user mode)
+        QWORD qwAffinity;
+        DWORD dwUserTime;
+        DWORD dwKernelTime;
+        UCHAR bSuspendCount;
+        UCHAR bWaitReason;
+        UCHAR _FutureUse1[2];
+        DWORD _FutureUse2[11];
+        QWORD vaImpersonationToken;
+        QWORD vaWin32StartAddress;
+    } VMMDLL_MAP_THREADENTRY, * PVMMDLL_MAP_THREADENTRY;
+
+    typedef struct tdVMMDLL_MAP_HANDLEENTRY {
+        QWORD vaObject;
+        DWORD dwHandle;
+        DWORD dwGrantedAccess : 24;
+        DWORD iType : 8;
+        QWORD qwHandleCount;
+        QWORD qwPointerCount;
+        QWORD vaObjectCreateInfo;
+        QWORD vaSecurityDescriptor;
+        union { LPSTR  uszText; LPWSTR wszText; };              // U/W dependant
+        DWORD _FutureUse2;
+        DWORD dwPID;
+        DWORD dwPoolTag;
+        DWORD _FutureUse[7];
+        union { LPSTR  uszType; LPWSTR wszType; QWORD _Pad1; }; // U/W dependant
+    } VMMDLL_MAP_HANDLEENTRY, * PVMMDLL_MAP_HANDLEENTRY;
+
+    typedef enum tdVMMDLL_MAP_POOL_TYPE {
+        VMMDLL_MAP_POOL_TYPE_Unknown = 0,
+        VMMDLL_MAP_POOL_TYPE_NonPagedPool = 1,
+        VMMDLL_MAP_POOL_TYPE_NonPagedPoolNx = 2,
+        VMMDLL_MAP_POOL_TYPE_PagedPool = 3
+    } VMMDLL_MAP_POOL_TYPE;
+
+    typedef enum tdVMM_MAP_POOL_TYPE_SUBSEGMENT {
+        VMM_MAP_POOL_TYPE_SUBSEGMENT_UNKNOWN = 0,
+        VMM_MAP_POOL_TYPE_SUBSEGMENT_NA = 1,
+        VMM_MAP_POOL_TYPE_SUBSEGMENT_BIG = 2,
+        VMM_MAP_POOL_TYPE_SUBSEGMENT_LARGE = 3,
+        VMM_MAP_POOL_TYPE_SUBSEGMENT_VS = 4,
+        VMM_MAP_POOL_TYPE_SUBSEGMENT_LFH = 5
+    } VMM_MAP_POOL_TYPE_SUBSEGMENT;
+
+    typedef struct tdVMMDLL_MAP_POOLENTRYTAG {
+        union {
+            CHAR szTag[5];
+            struct {
+                DWORD dwTag;
+                DWORD _Filler;
+                DWORD cEntry;
+                DWORD iTag2Map;
+            };
+        };
+    } VMMDLL_MAP_POOLENTRYTAG, * PVMMDLL_MAP_POOLENTRYTAG;
+
+    typedef struct tdVMMDLL_MAP_POOLENTRY {
+        QWORD va;
+        union {
+            CHAR szTag[5];
+            struct {
+                DWORD dwTag;
+                BYTE _ReservedZero;
+                BYTE fAlloc;
+                BYTE tpPool;    // VMMDLL_MAP_POOL_TYPE
+                BYTE tpSS;      // VMMDLL_MAP_POOL_TYPE_SUBSEGMENT
+            };
+        };
+        DWORD cb;
+        DWORD _Filler;
+    } VMMDLL_MAP_POOLENTRY, * PVMMDLL_MAP_POOLENTRY;
+
+    typedef struct tdVMMDLL_MAP_NETENTRY {
+        DWORD dwPID;
+        DWORD dwState;
+        WORD _FutureUse3[3];
+        WORD AF;                        // address family (IPv4/IPv6)
+        struct {
+            BOOL fValid;
+            WORD _Reserved;
+            WORD port;
+            BYTE pbAddr[16];            // ipv4 = 1st 4 bytes, ipv6 = all bytes
+            union { LPSTR  uszText; LPWSTR wszText; };          // U/W dependant
+        } Src;
+        struct {
+            BOOL fValid;
+            WORD _Reserved;
+            WORD port;
+            BYTE pbAddr[16];            // ipv4 = 1st 4 bytes, ipv6 = all bytes
+            union { LPSTR  uszText; LPWSTR wszText; };          // U/W dependant
+        } Dst;
+        QWORD vaObj;
+        QWORD ftTime;
+        DWORD dwPoolTag;
+        DWORD _FutureUse4;
+        union { LPSTR  uszText; LPWSTR wszText; };              // U/W dependant
+        DWORD _FutureUse2[4];
+    } VMMDLL_MAP_NETENTRY, * PVMMDLL_MAP_NETENTRY;
+
+    typedef struct tdVMMDLL_MAP_PHYSMEMENTRY {
+        QWORD pa;
+        QWORD cb;
+    } VMMDLL_MAP_PHYSMEMENTRY, * PVMMDLL_MAP_PHYSMEMENTRY;
+
+    typedef struct tdVMMDLL_MAP_USERENTRY {
+        DWORD _FutureUse1[2];
+        union { LPSTR  uszText; LPWSTR wszText; };              // U/W dependant
+        ULONG64 vaRegHive;
+        union { LPSTR  uszSID; LPWSTR wszSID; };                // U/W dependant
+        DWORD _FutureUse2[2];
+    } VMMDLL_MAP_USERENTRY, * PVMMDLL_MAP_USERENTRY;
+
+    typedef enum tdVMMDLL_VM_TP {
+        VMMDLL_VM_TP_UNKNOWN = 0,
+        VMMDLL_VM_TP_HV = 1,
+        VMMDLL_VM_TP_HV_WHVP = 2
+    } VMMDLL_VM_TP;
+
+    typedef struct tdVMMDLL_MAP_VMENTRY {
+        VMMVM_HANDLE hVM;
+        union { LPSTR  uszName; LPWSTR wszName; };              // U/W dependant
+        QWORD gpaMax;
+        VMMDLL_VM_TP tp;
+        BOOL fActive;
+        BOOL fReadOnly;
+        BOOL fPhysicalOnly;
+        DWORD dwPartitionID;
+        DWORD dwVersionBuild;
+        VMMDLL_SYSTEM_TP tpSystem;
+        DWORD dwParentVmmMountID;
+        DWORD dwVmMemPID;
+    } VMMDLL_MAP_VMENTRY, * PVMMDLL_MAP_VMENTRY;
+
+    typedef struct tdVMMDLL_MAP_SERVICEENTRY {
+        QWORD vaObj;
+        DWORD dwOrdinal;
+        DWORD dwStartType;
+        SERVICE_STATUS ServiceStatus;
+        union { LPSTR  uszServiceName; LPWSTR wszServiceName; QWORD _Reserved1; };  // U/W dependant
+        union { LPSTR  uszDisplayName; LPWSTR wszDisplayName; QWORD _Reserved2; };  // U/W dependant
+        union { LPSTR  uszPath;        LPWSTR wszPath;        QWORD _Reserved3; };  // U/W dependant
+        union { LPSTR  uszUserTp;      LPWSTR wszUserTp;      QWORD _Reserved4; };  // U/W dependant
+        union { LPSTR  uszUserAcct;    LPWSTR wszUserAcct;    QWORD _Reserved5; };  // U/W dependant
+        union { LPSTR  uszImagePath;   LPWSTR wszImagePath;   QWORD _Reserved6; };  // U/W dependant
+        DWORD dwPID;
+        DWORD _FutureUse1;
+        QWORD _FutureUse2;
+    } VMMDLL_MAP_SERVICEENTRY, * PVMMDLL_MAP_SERVICEENTRY;
+
+    typedef struct tdVMMDLL_MAP_PTE {
+        DWORD dwVersion;                // VMMDLL_MAP_PTE_VERSION
+        DWORD _Reserved1[5];
+        PBYTE pbMultiText;              // NULL or multi-wstr pointed into by VMMDLL_MAP_VADENTRY.wszText
+        DWORD cbMultiText;
+        DWORD cMap;                     // # map entries.
+        VMMDLL_MAP_PTEENTRY pMap[];     // map entries.
+    } VMMDLL_MAP_PTE, * PVMMDLL_MAP_PTE;
+
+    typedef struct tdVMMDLL_MAP_VAD {
+        DWORD dwVersion;                // VMMDLL_MAP_VAD_VERSION
+        DWORD _Reserved1[4];
+        DWORD cPage;                    // # pages in vad map.
+        PBYTE pbMultiText;              // NULL or multi-wstr pointed into by VMMDLL_MAP_VADENTRY.wszText
+        DWORD cbMultiText;
+        DWORD cMap;                     // # map entries.
+        VMMDLL_MAP_VADENTRY pMap[];     // map entries.
+    } VMMDLL_MAP_VAD, * PVMMDLL_MAP_VAD;
+
+    typedef struct tdVMMDLL_MAP_VADEX {
+        DWORD dwVersion;                // VMMDLL_MAP_VADEX_VERSION
+        DWORD _Reserved1[4];
+        DWORD cMap;                     // # map entries.
+        VMMDLL_MAP_VADEXENTRY pMap[];   // map entries.
+    } VMMDLL_MAP_VADEX, * PVMMDLL_MAP_VADEX;
+
+    typedef struct tdVMMDLL_MAP_MODULE {
+        DWORD dwVersion;                // VMMDLL_MAP_MODULE_VERSION
+        DWORD _Reserved1[5];
+        PBYTE pbMultiText;              // multi-wstr pointed into by VMMDLL_MAP_MODULEENTRY.wszText
+        DWORD cbMultiText;
+        DWORD cMap;                     // # map entries.
+        VMMDLL_MAP_MODULEENTRY pMap[];  // map entries.
+    } VMMDLL_MAP_MODULE, * PVMMDLL_MAP_MODULE;
+
+    typedef struct tdVMMDLL_MAP_UNLOADEDMODULE {
+        DWORD dwVersion;                // VMMDLL_MAP_UNLOADEDMODULE_VERSION
+        DWORD _Reserved1[5];
+        PBYTE pbMultiText;              // multi-wstr pointed into by VMMDLL_MAP_MODULEENTRY.wszText
+        DWORD cbMultiText;
+        DWORD cMap;                     // # map entries.
+        VMMDLL_MAP_UNLOADEDMODULEENTRY pMap[];  // map entries.
+    } VMMDLL_MAP_UNLOADEDMODULE, * PVMMDLL_MAP_UNLOADEDMODULE;
+
+    typedef struct tdVMMDLL_MAP_EAT {
+        DWORD dwVersion;                // VMMDLL_MAP_EAT_VERSION
+        DWORD dwOrdinalBase;
+        DWORD cNumberOfNames;
+        DWORD cNumberOfFunctions;
+        DWORD cNumberOfForwardedFunctions;
+        DWORD _Reserved1[3];
+        QWORD vaModuleBase;
+        QWORD vaAddressOfFunctions;
+        QWORD vaAddressOfNames;
+        PBYTE pbMultiText;              // multi-str pointed into by VMM_MAP_EATENTRY.wszFunction
+        DWORD cbMultiText;
+        DWORD cMap;                     // # map entries.
+        VMMDLL_MAP_EATENTRY pMap[];     // map entries.
+    } VMMDLL_MAP_EAT, * PVMMDLL_MAP_EAT;
+
+    typedef struct tdVMMDLL_MAP_IAT {
+        DWORD dwVersion;                // VMMDLL_MAP_IAT_VERSION
+        DWORD _Reserved1[5];
+        QWORD vaModuleBase;
+        PBYTE pbMultiText;              // multi-str pointed into by VMM_MAP_EATENTRY.[wszFunction|wszModule]
+        DWORD cbMultiText;
+        DWORD cMap;                     // # map entries.
+        VMMDLL_MAP_IATENTRY pMap[];     // map entries.
+    } VMMDLL_MAP_IAT, * PVMMDLL_MAP_IAT;
+
+    typedef struct tdVMMDLL_MAP_HEAP {
+        DWORD dwVersion;                            // VMMDLL_MAP_HEAP_VERSION
+        DWORD _Reserved1[7];
+        PVMMDLL_MAP_HEAP_SEGMENTENTRY pSegments;    // heap segment entries.
+        DWORD cSegments;                            // # heap segment entries.
+        DWORD cMap;                                 // # map entries.
+        VMMDLL_MAP_HEAPENTRY pMap[];                // map entries.
+    } VMMDLL_MAP_HEAP, * PVMMDLL_MAP_HEAP;
+
+    typedef struct tdVMMDLL_MAP_HEAPALLOC {
+        DWORD dwVersion;                    // VMMDLL_MAP_HEAPALLOC_VERSION
+        DWORD _Reserved1[7];
+        PVOID _Reserved2[2];
+        DWORD cMap;                         // # map entries.
+        VMMDLL_MAP_HEAPALLOCENTRY pMap[];   // map entries.
+    } VMMDLL_MAP_HEAPALLOC, * PVMMDLL_MAP_HEAPALLOC;
+
+    typedef struct tdVMMDLL_MAP_THREAD {
+        DWORD dwVersion;                // VMMDLL_MAP_THREAD_VERSION
+        DWORD _Reserved[8];
+        DWORD cMap;                     // # map entries.
+        VMMDLL_MAP_THREADENTRY pMap[];  // map entries.
+    } VMMDLL_MAP_THREAD, * PVMMDLL_MAP_THREAD;
+
+    typedef struct tdVMMDLL_MAP_HANDLE {
+        DWORD dwVersion;                // VMMDLL_MAP_HANDLE_VERSION
+        DWORD _Reserved1[5];
+        PBYTE pbMultiText;              // multi-wstr pointed into by VMMDLL_MAP_HANDLEENTRY.wszText
+        DWORD cbMultiText;
+        DWORD cMap;                     // # map entries.
+        VMMDLL_MAP_HANDLEENTRY pMap[];  // map entries.
+    } VMMDLL_MAP_HANDLE, * PVMMDLL_MAP_HANDLE;
+
+    typedef struct tdVMMDLL_MAP_POOL {
+        DWORD dwVersion;                // VMMDLL_MAP_POOL_VERSION
+        DWORD _Reserved1[6];
+        DWORD cbTotal;                  // # bytes to represent this pool map object
+        PDWORD piTag2Map;               // dword map array (size: cMap): tag index to map index.
+        PVMMDLL_MAP_POOLENTRYTAG pTag;  // tag entries.
+        DWORD cTag;                     // # tag entries.
+        DWORD cMap;                     // # map entries.
+        VMMDLL_MAP_POOLENTRY pMap[];    // map entries.
+    } VMMDLL_MAP_POOL, * PVMMDLL_MAP_POOL;
+
+    typedef struct tdVMMDLL_MAP_NET {
+        DWORD dwVersion;                // VMMDLL_MAP_NET_VERSION
+        DWORD _Reserved1;
+        PBYTE pbMultiText;              // multi-wstr pointed into by VMM_MAP_NETENTRY.wszText
+        DWORD cbMultiText;
+        DWORD cMap;                     // # map entries.
+        VMMDLL_MAP_NETENTRY pMap[];     // map entries.
+    } VMMDLL_MAP_NET, * PVMMDLL_MAP_NET;
+
+    typedef struct tdVMMDLL_MAP_PHYSMEM {
+        DWORD dwVersion;                // VMMDLL_MAP_PHYSMEM_VERSION
+        DWORD _Reserved1[5];
+        DWORD cMap;                     // # map entries.
+        DWORD _Reserved2;
+        VMMDLL_MAP_PHYSMEMENTRY pMap[]; // map entries.
+    } VMMDLL_MAP_PHYSMEM, * PVMMDLL_MAP_PHYSMEM;
+
+    typedef struct tdVMMDLL_MAP_USER {
+        DWORD dwVersion;                // VMMDLL_MAP_USER_VERSION
+        DWORD _Reserved1[5];
+        PBYTE pbMultiText;              // multi-wstr pointed into by VMMDLL_MAP_USERENTRY.wszText
+        DWORD cbMultiText;
+        DWORD cMap;                     // # map entries.
+        VMMDLL_MAP_USERENTRY pMap[];    // map entries.
+    } VMMDLL_MAP_USER, * PVMMDLL_MAP_USER;
+
+    typedef struct tdVMMDLL_MAP_VM {
+        DWORD dwVersion;                // VMMDLL_MAP_VM_VERSION
+        DWORD _Reserved1[5];
+        PBYTE pbMultiText;              // multi-wstr pointed into by VMMDLL_MAP_VMENTRY.wszText
+        DWORD cbMultiText;
+        DWORD cMap;                     // # map entries.
+        VMMDLL_MAP_VMENTRY pMap[];      // map entries.
+    } VMMDLL_MAP_VM, * PVMMDLL_MAP_VM;
+
+    typedef struct tdVMMDLL_MAP_SERVICE {
+        DWORD dwVersion;                // VMMDLL_MAP_SERVICE_VERSION
+        DWORD _Reserved1[5];
+        PBYTE pbMultiText;              // multi-wstr pointed into by VMMDLL_MAP_SERVICEENTRY.wsz*
+        DWORD cbMultiText;
+        DWORD cMap;                     // # map entries.
+        VMMDLL_MAP_SERVICEENTRY pMap[]; // map entries.
+    } VMMDLL_MAP_SERVICE, * PVMMDLL_MAP_SERVICE;
+
+    /*
+    * Retrieve the memory map entries based on hardware page tables (PTEs) for the process.
+    * Entries returned are sorted on VMMDLL_MAP_PTEENTRY.va
+    * CALLER FREE: VMMDLL_MemFree(*ppVadMap)
+    * -- hVMM
+    * -- dwPID
+    * -- fIdentifyModules = try identify modules as well (= slower)
+    * -- ppPteMap =  ptr to receive result on success. must be free'd with VMMDLL_MemFree().
+    * -- return = success/fail.
+    */
+    EXPORTED_FUNCTION
+        _Success_(return) BOOL VMMDLL_Map_GetPteU(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_ BOOL fIdentifyModules, _Out_ PVMMDLL_MAP_PTE* ppPteMap);
+    _Success_(return) BOOL VMMDLL_Map_GetPteW(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_ BOOL fIdentifyModules, _Out_ PVMMDLL_MAP_PTE* ppPteMap);
+
+    /*
+    * Retrieve memory map entries based on virtual address descriptor (VAD) for the process.
+    * Entries returned are sorted on VMMDLL_MAP_VADENTRY.vaStart
+    * CALLER FREE: VMMDLL_MemFree(*ppVadMap)
+    * -- hVMM
+    * -- dwPID
+    * -- fIdentifyModules = try identify modules as well (= slower)
+    * -- ppVadMap =  ptr to receive result on success. must be free'd with VMMDLL_MemFree().
+    * -- return = success/fail.
+    */
+    EXPORTED_FUNCTION
+        _Success_(return) BOOL VMMDLL_Map_GetVadU(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_ BOOL fIdentifyModules, _Out_ PVMMDLL_MAP_VAD* ppVadMap);
+    _Success_(return) BOOL VMMDLL_Map_GetVadW(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_ BOOL fIdentifyModules, _Out_ PVMMDLL_MAP_VAD* ppVadMap);
+
+    /*
+    * Retrieve extended memory map information about a sub-set of the memory map.
+    * CALLER FREE: VMMDLL_MemFree(*ppVadExMap)
+    * -- hVMM
+    * -- oPage = offset in number of pages from process start.
+    * -- cPage = number of pages to process from oPages base.
+    * -- ppVadExMap =  ptr to receive result on success. must be free'd with VMMDLL_MemFree().
+    * -- return = success/fail.
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_Map_GetVadEx(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_ DWORD oPage, _In_ DWORD cPage, _Out_ PVMMDLL_MAP_VADEX* ppVadExMap);
+
+    /*
+    * Retrieve the modules (.dlls) for the specified process.
+    * CALLER FREE: VMMDLL_MemFree(*ppModuleMap)
+    * -- hVMM
+    * -- dwPID
+    * -- ppModuleMap =  ptr to receive result on success. must be free'd with VMMDLL_MemFree().
+    * -- flags = optional flags as specified by VMMDLL_MODULE_FLAG_*
+    * -- return = success/fail.
+    */
+    EXPORTED_FUNCTION
+        _Success_(return) BOOL VMMDLL_Map_GetModuleU(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _Out_ PVMMDLL_MAP_MODULE* ppModuleMap, _In_ DWORD flags);
+    _Success_(return) BOOL VMMDLL_Map_GetModuleW(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _Out_ PVMMDLL_MAP_MODULE* ppModuleMap, _In_ DWORD flags);
+
+    /*
+    * Retrieve a module (.dll) entry given a process and module name.
+    * CALLER FREE: VMMDLL_MemFree(*ppModuleMapEntry)
+    * -- hVMM
+    * -- dwPID
+    * -- [uw]szModuleName = module name (or ""/NULL for 1st module entry).
+    * -- ppModuleMapEntry =  ptr to receive result on success. must be free'd with VMMDLL_MemFree().
+    * -- flags = optional flags as specified by VMMDLL_MODULE_FLAG_*
+    * -- return = success/fail.
+    */
+    EXPORTED_FUNCTION
+        _Success_(return) BOOL VMMDLL_Map_GetModuleFromNameU(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_opt_ LPSTR  uszModuleName, _Out_ PVMMDLL_MAP_MODULEENTRY* ppModuleMapEntry, _In_ DWORD flags);
+    _Success_(return) BOOL VMMDLL_Map_GetModuleFromNameW(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_opt_ LPWSTR wszModuleName, _Out_ PVMMDLL_MAP_MODULEENTRY* ppModuleMapEntry, _In_ DWORD flags);
+
+    /*
+    * Retrieve the unloaded modules (.dll/.sys) for the specified process.
+    * CALLER FREE: VMMDLL_MemFree(*ppUnloadedModuleMap)
+    * -- hVMM
+    * -- dwPID
+    * -- ppUnloadedModuleMap =  ptr to receive result on success. must be free'd with VMMDLL_MemFree().
+    * -- return = success/fail.
+    */
+    EXPORTED_FUNCTION
+        _Success_(return) BOOL VMMDLL_Map_GetUnloadedModuleU(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _Out_ PVMMDLL_MAP_UNLOADEDMODULE* ppUnloadedModuleMap);
+    _Success_(return) BOOL VMMDLL_Map_GetUnloadedModuleW(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _Out_ PVMMDLL_MAP_UNLOADEDMODULE* ppUnloadedModuleMap);
+
+    /*
+    * Retrieve the module exported functions from the export address table (EAT).
+    * CALLER FREE: VMMDLL_MemFree(*ppEatMap)
+    * -- hVMM
+    * -- dwPID
+    * -- [uw]szModuleName
+    * -- ppEatMap =  ptr to receive result on success. must be free'd with VMMDLL_MemFree().
+    * -- return = success/fail.
+    */
+    EXPORTED_FUNCTION
+        _Success_(return) BOOL VMMDLL_Map_GetEATU(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_ LPSTR  uszModuleName, _Out_ PVMMDLL_MAP_EAT* ppEatMap);
+    _Success_(return) BOOL VMMDLL_Map_GetEATW(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_ LPWSTR wszModuleName, _Out_ PVMMDLL_MAP_EAT* ppEatMap);
+
+    /*
+    * Retrieve the module imported functions from the import address table (IAT).
+    * CALLER FREE: VMMDLL_MemFree(*ppIatMap)
+    * -- hVMM
+    * -- dwPID
+    * -- [uw]szModuleName
+    * -- ppIatMap =  ptr to receive result on success. must be free'd with VMMDLL_MemFree().
+    * -- return = success/fail.
+    */
+    EXPORTED_FUNCTION
+        _Success_(return) BOOL VMMDLL_Map_GetIATU(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_ LPSTR  uszModuleName, _Out_ PVMMDLL_MAP_IAT* ppIatMap);
+    _Success_(return) BOOL VMMDLL_Map_GetIATW(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_ LPWSTR wszModuleName, _Out_ PVMMDLL_MAP_IAT* ppIatMap);
+
+    /*
+    * Retrieve the heaps for the specified process.
+    * CALLER FREE: VMMDLL_MemFree(*ppHeapMap)
+    * -- hVMM
+    * -- dwPID
+    * -- ppHeapMap =  ptr to receive result on success. must be free'd with VMMDLL_MemFree().
+    * -- return = success/fail.
+    */
+    EXPORTED_FUNCTION
+        _Success_(return) BOOL VMMDLL_Map_GetHeap(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _Out_ PVMMDLL_MAP_HEAP* ppHeapMap);
+
+    /*
+    * Retrieve heap allocations for the specified process heap.
+    * CALLER FREE: VMMDLL_MemFree(*ppHeapAllocMap)
+    * -- hVMM
+    * -- dwPID
+    * -- qwHeapNumOrAddress = number or virtual address of heap to retrieve allocations from.
+    * -- ppHeapAllocMap =  ptr to receive result on success. must be free'd with VMMDLL_MemFree().
+    * -- return = success/fail.
+    */
+    EXPORTED_FUNCTION
+        _Success_(return) BOOL VMMDLL_Map_GetHeapAlloc(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_ QWORD qwHeapNumOrAddress, _Out_ PVMMDLL_MAP_HEAPALLOC* ppHeapAllocMap);
+
+    /*
+    * Retrieve the threads for the specified process.
+    * Entries returned are sorted on VMMDLL_MAP_THREADENTRY.dwTID
+    * CALLER FREE: VMMDLL_MemFree(*ppThreadMap)
+    * -- hVMM
+    * -- dwPID
+    * -- ppThreadMap = ptr to receive result on success. must be free'd with VMMDLL_MemFree().
+    * -- return = success/fail.
+    */
+    EXPORTED_FUNCTION
+        _Success_(return) BOOL VMMDLL_Map_GetThread(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _Out_ PVMMDLL_MAP_THREAD* ppThreadMap);
+
+    /*
+    * Retrieve the handles for the specified process.
+    * Entries returned are sorted on VMMDLL_MAP_HANDLEENTRY.dwHandle
+    * CALLER FREE: VMMDLL_MemFree(*ppHandleMap)
+    * -- hVMM
+    * -- dwPID
+    * -- ppHandleMap = ptr to receive result on success. must be free'd with VMMDLL_MemFree().
+    * -- return = success/fail.
+    */
+    EXPORTED_FUNCTION
+        _Success_(return) BOOL VMMDLL_Map_GetHandleU(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _Out_ PVMMDLL_MAP_HANDLE* ppHandleMap);
+    _Success_(return) BOOL VMMDLL_Map_GetHandleW(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _Out_ PVMMDLL_MAP_HANDLE* ppHandleMap);
+
+    /*
+    * Retrieve the physical memory ranges from the operating system physical memory map.
+    * CALLER FREE: VMMDLL_MemFree(*ppPhysMemMap)
+    * -- hVMM
+    * -- ppPhysMemMap = ptr to receive result on success. must be free'd with VMMDLL_MemFree()
+    * -- return = success/fail.
+    */
+    EXPORTED_FUNCTION
+        _Success_(return) BOOL VMMDLL_Map_GetPhysMem(_In_ VMM_HANDLE hVMM, _Out_ PVMMDLL_MAP_PHYSMEM* ppPhysMemMap);
+
+    /*
+    * Retrieve the pool map - consisting of kernel allocated pool entries.
+    * The pool map pMap is sorted by allocation virtual address.
+    * The pool map pTag is sorted by pool tag.
+    * NB! The pool map may contain both false negatives/positives.
+    * NB! The pool map relies on debug symbols. Please ensure supporting files
+    *     symsrv.dll, dbghelp.dll and info.db (found in the binary distribution)
+    *     is put alongside vmm.dll. (On Linux the .dll files aren't necessary).
+    * CALLER FREE: VMMDLL_MemFree(*ppPoolMap)
+    * -- hVMM
+    * -- ppPoolMap = ptr to receive result on success. must be free'd with VMMDLL_MemFree().
+    * -- flags = VMMDLL_POOLMAP_FLAG*
+    * -- return = success/fail.
+    */
+    EXPORTED_FUNCTION
+        _Success_(return) BOOL VMMDLL_Map_GetPool(_In_ VMM_HANDLE hVMM, _Out_ PVMMDLL_MAP_POOL* ppPoolMap, _In_ DWORD flags);
+
+    /*
+    * Retrieve the network connection map - consisting of active network connections,
+    * listening sockets and other networking functionality.
+    * CALLER FREE: VMMDLL_MemFree(*ppNetMap)
+    * -- hVMM
+    * -- ppNetMap = ptr to receive result on success. must be free'd with VMMDLL_MemFree().
+    * -- return = success/fail.
+    */
+    EXPORTED_FUNCTION
+        _Success_(return) BOOL VMMDLL_Map_GetNetU(_In_ VMM_HANDLE hVMM, _Out_ PVMMDLL_MAP_NET* ppNetMap);
+    _Success_(return) BOOL VMMDLL_Map_GetNetW(_In_ VMM_HANDLE hVMM, _Out_ PVMMDLL_MAP_NET* ppNetMap);
+
+    /*
+    * Retrieve the non well known users that are detected in the target system.
+    * NB! There may be more users in the system than the ones that are detected,
+    * only users with mounted registry hives may currently be detected - this is
+    * the normal behaviour for users with active processes.
+    * CALLER FREE: VMMDLL_MemFree(*ppUserMap)
+    * -- hVMM
+    * -- ppUserMap = ptr to receive result on success. must be free'd with VMMDLL_MemFree().
+    * -- return = success/fail.
+    */
+    EXPORTED_FUNCTION
+        _Success_(return) BOOL VMMDLL_Map_GetUsersU(_In_ VMM_HANDLE hVMM, _Out_ PVMMDLL_MAP_USER* ppUserMap);
+    _Success_(return) BOOL VMMDLL_Map_GetUsersW(_In_ VMM_HANDLE hVMM, _Out_ PVMMDLL_MAP_USER* ppUserMap);
+
+    /*
+    * Retrieve a map of detected child virtual machines (VMs).
+    * NB! May fail if called shortly after vmm init unless option: -waitinitialize
+    * CALLER FREE: VMMDLL_MemFree(*ppVmMap)
+    * -- hVMM
+    * -- ppVmMap = ptr to receive result on success. must be free'd with VMMDLL_MemFree().
+    * -- return = success/fail.
+    */
+    EXPORTED_FUNCTION
+        _Success_(return) BOOL VMMDLL_Map_GetVMU(_In_ VMM_HANDLE hVMM, _Out_ PVMMDLL_MAP_VM* ppVmMap);
+    _Success_(return) BOOL VMMDLL_Map_GetVMW(_In_ VMM_HANDLE hVMM, _Out_ PVMMDLL_MAP_VM* ppVmMap);
+
+    /*
+    * Retrieve the services currently known by the service control manager (SCM).
+    * CALLER FREE: VMMDLL_MemFree(*ppServiceMap)
+    * -- hVMM
+    * -- ppServiceMap = ptr to receive result on success. must be free'd with VMMDLL_MemFree().
+    * -- return = success/fail.
+    */
+    EXPORTED_FUNCTION
+        _Success_(return) BOOL VMMDLL_Map_GetServicesU(_In_ VMM_HANDLE hVMM, _Out_ PVMMDLL_MAP_SERVICE* ppServiceMap);
+    _Success_(return) BOOL VMMDLL_Map_GetServicesW(_In_ VMM_HANDLE hVMM, _Out_ PVMMDLL_MAP_SERVICE* ppServiceMap);
+
+
+
+    //-----------------------------------------------------------------------------
+    // MEMORY SEARCH FUNCTIONALITY:
+    //-----------------------------------------------------------------------------
+
+#define VMMDLL_MEM_SEARCH_VERSION           0xfe3e0002
+#define VMMDLL_MEM_SEARCH_MAX               16
+#define VMMDLL_MEM_SEARCH_MAXLENGTH         32
+
+    typedef struct tdVMMDLL_MEM_SEARCH_CONTEXT_SEARCHENTRY {
+        DWORD cbAlign;                                  // byte-align at 2^x - 0, 1, 2, 4, 8, 16, .. bytes.
+        DWORD cb;                                       // number of bytes to search (1-32).
+        BYTE pb[VMMDLL_MEM_SEARCH_MAXLENGTH];
+        BYTE pbSkipMask[VMMDLL_MEM_SEARCH_MAXLENGTH];   // skip bitmask '0' = match, '1' = wildcard.
+    } VMMDLL_MEM_SEARCH_CONTEXT_SEARCHENTRY, * PVMMDLL_MEM_SEARCH_CONTEXT_SEARCHENTRY;
+
+    /*
+    * Context to populate and use in the VMMDLL_MemSearch() function.
+    */
+    typedef struct tdVMMDLL_MEM_SEARCH_CONTEXT {
+        DWORD dwVersion;
+        DWORD _Filler[2];
+        BOOL fAbortRequested;       // may be set by caller to abort processing prematurely.
+        DWORD cMaxResult;           // # max result entries. '0' = 1 entry. max 0x10000 entries.
+        DWORD cSearch;              // number of search entries.
+        VMMDLL_MEM_SEARCH_CONTEXT_SEARCHENTRY search[VMMDLL_MEM_SEARCH_MAX];
+        QWORD vaMin;                // min address to search (page-aligned).
+        QWORD vaMax;                // max address to search (page-aligned), if 0 max memory is assumed.
+        QWORD vaCurrent;            // current address (may be read by caller).
+        DWORD _Filler2;
+        DWORD cResult;              // number of search hits.
+        QWORD cbReadTotal;          // total number of bytes read.
+        PVOID pvUserPtrOpt;         // optional pointer set by caller (used for context passing to callbacks)
+        // optional result callback function.
+        // use of callback function disable ordinary result in ppObAddressResult.
+        // return = continue search(TRUE), abort search(FALSE).
+        BOOL(*pfnResultOptCB)(_In_ struct tdVMMDLL_MEM_SEARCH_CONTEXT* ctx, _In_ QWORD va, _In_ DWORD iSearch);
+        // non-recommended features:
+        QWORD ReadFlags;            // read flags as in VMMDLL_FLAG_*
+        BOOL fForcePTE;             // force PTE method for virtual address reads.
+        BOOL fForceVAD;             // force VAD method for virtual address reads.
+        // optional filter callback function for virtual address reads:
+        // for ranges inbetween vaMin:vaMax callback with pte or vad entry.
+        // return: read from range(TRUE), do not read from range(FALSE).
+        BOOL(*pfnFilterOptCB)(_In_ struct tdVMMDLL_MEM_SEARCH_CONTEXT* ctx, _In_opt_ PVMMDLL_MAP_PTEENTRY pePte, _In_opt_ PVMMDLL_MAP_VADENTRY peVad);
+    } VMMDLL_MEM_SEARCH_CONTEXT, * PVMMDLL_MEM_SEARCH_CONTEXT;
+
+    /*
+    * Search for binary data in an address space specified by the supplied context.
+    * For more information about the different search parameters please see the
+    * struct definition: VMMDLL_MEM_SEARCH_CONTEXT
+    * Search may take a long time. It's not recommended to run this interactively.
+    * To cancel a search prematurely set the fAbortRequested flag in the context
+    * and wait a short while.
+    * CALLER FREE: VMMDLL_MemFree(*ppva)
+    * -- hVMM
+    * -- dwPID - PID of target process, (DWORD)-1 to read physical memory.
+    * -- ctx
+    * -- ppva = pointer to receive addresses found. Free'd with VMMDLL_MemFree().
+    * -- pcva = pointer to receive number of addresses in ppva. not bytes!
+    * -- return
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_MemSearch(
+            _In_ VMM_HANDLE hVMM,
+            _In_ DWORD dwPID,
+            _Inout_ PVMMDLL_MEM_SEARCH_CONTEXT ctx,
+            _Out_opt_ PQWORD* ppva,
+            _Out_opt_ PDWORD pcva
+        );
+
+
+
+    //-----------------------------------------------------------------------------
+    // MEMORY YARA SEARCH FUNCTIONALITY:
+    // The yara search functionality requires that vmmyara.[dll|so] is present.
+    // The vmmyara project is found at: https://github.com/ufrisk/vmmyara
+    //-----------------------------------------------------------------------------
+
+    // =========== START SHARED STRUCTS WITH <vmmdll.h/vmmyara.h> ===========
+#ifndef VMMYARA_RULE_MATCH_DEFINED
+#define VMMYARA_RULE_MATCH_DEFINED
+
+#define VMMYARA_RULE_MATCH_VERSION          0xfedc0003
+#define VMMYARA_RULE_MATCH_TAG_MAX          8
+#define VMMYARA_RULE_MATCH_META_MAX         16
+#define VMMYARA_RULE_MATCH_STRING_MAX       8
+#define VMMYARA_RULE_MATCH_OFFSET_MAX       16
 
 /*
-* Retrieve the memory map entries based on hardware page tables (PTE) for the
-* process. If pPteMap is set to NULL the number of bytes required will be
-* returned in parameter pcbPteMap.
-* Entries returned are sorted on VMMDLL_MAP_PTEENTRY.vaBase
-* -- dwPID
-* -- pPteMap = buffer of minimum byte length *pcbPteMap or NULL.
-* -- pcbPteMap = pointer to byte count of pPteMap buffer.
-* -- fIdentifyModules = try identify modules as well (= slower)
-* -- return = success/fail.
+* Struct with match information upon a match in VmmYara_RulesScanMemory().
 */
-_Success_(return)
-BOOL VMMDLL_ProcessMap_GetPte(_In_ DWORD dwPID, _Out_writes_bytes_opt_(*pcbPteMap) PVMMDLL_MAP_PTE pPteMap, _Inout_ PDWORD pcbPteMap, _In_ BOOL fIdentifyModules);
+    typedef struct tdVMMYARA_RULE_MATCH {
+        DWORD dwVersion;                    // VMMYARA_RULE_MATCH_VERSION
+        DWORD flags;
+        LPSTR szRuleIdentifier;
+        DWORD cTags;
+        LPSTR szTags[VMMYARA_RULE_MATCH_TAG_MAX];
+        DWORD cMeta;
+        struct {
+            LPSTR szIdentifier;
+            LPSTR szString;
+        } Meta[VMMYARA_RULE_MATCH_META_MAX];
+        DWORD cStrings;
+        struct {
+            LPSTR szString;
+            DWORD cMatch;
+            SIZE_T cbMatchOffset[VMMYARA_RULE_MATCH_OFFSET_MAX];
+        } Strings[VMMYARA_RULE_MATCH_STRING_MAX];
+    } VMMYARA_RULE_MATCH, * PVMMYARA_RULE_MATCH;
 
-/*
-* Retrieve memory map entries based on virtual address descriptor (VAD) for
-* the process. If pVadMap is set to NULL the number of bytes required
-* will be returned in parameter pcbVadMap.
-* Entries returned are sorted on VMMDLL_MAP_VADENTRY.vaStart
-* -- dwPID
-* -- pVadMap = buffer of minimum byte length *pcbVadMap or NULL.
-* -- pcbVadMap = pointer to byte count of pVadMap buffer.
-* -- fIdentifyModules = try identify modules as well (= slower)
-* -- return = success/fail.
-*/
-_Success_(return)
-BOOL VMMDLL_ProcessMap_GetVad(_In_ DWORD dwPID, _Out_writes_bytes_opt_(*pcbVadMap) PVMMDLL_MAP_VAD pVadMap, _Inout_ PDWORD pcbVadMap, _In_ BOOL fIdentifyModules);
+#endif /* VMMYARA_RULE_MATCH_DEFINED */
 
-/*
-* Retrieve the modules (.dlls) for the specified process. If pModuleMap is set
-* to NULL the number of bytes required will be returned in parameter pcbModuleMap.
-* -- dwPID
-* -- pModuleMap = buffer of minimum byte length *pcbModuleMap or NULL.
-* -- pcbModuleMap = pointer to byte count of pModuleMap buffer.
-* -- return = success/fail.
-*/
-_Success_(return)
-BOOL VMMDLL_ProcessMap_GetModule(_In_ DWORD dwPID, _Out_writes_bytes_opt_(*pcbModuleMap) PVMMDLL_MAP_MODULE pModuleMap, _Inout_ PDWORD pcbModuleMap);
+#ifndef VMMYARA_SCAN_MEMORY_CALLBACK_DEFINED
+#define VMMYARA_SCAN_MEMORY_CALLBACK_DEFINED
 
-/*
-* Retrieve a module map entry (.exe / .dll) given a process and module name.
-* NB! PVMMDLL_MAP_MODULEENTRY->wszText will not be set by this function.
-* If module name is required use VMMDLL_ProcessMap_GetModule().
-* -- dwPID
-* -- szModuleName
-* -- pModuleMapEntry
-* -- return = success/fail.
-*/
-_Success_(return)
-BOOL VMMDLL_ProcessMap_GetModuleFromName(_In_ DWORD dwPID, _In_ LPWSTR wszModuleName, _Out_ PVMMDLL_MAP_MODULEENTRY pModuleMapEntry);
+    /*
+    * Callback function to be called by VmmYara_RulesScanMemory() upon a match.
+    * -- pvContext = user context set in call to VmmYara_ScanMemory().
+    * -- pRuleMatch = pointer to match information.
+    * -- pbBuffer = the memory buffer that was scanned.
+    * -- cbBuffer = the size of the memory buffer that was scanned.
+    * -- return = return TRUE to continue scanning, FALSE to stop scanning.
+    */
+    typedef BOOL(*VMMYARA_SCAN_MEMORY_CALLBACK)(
+        _In_ PVOID pvContext,
+        _In_ PVMMYARA_RULE_MATCH pRuleMatch,
+        _In_reads_bytes_(cbBuffer) PBYTE pbBuffer,
+        _In_ SIZE_T cbBuffer
+        );
 
-/*
-* Retrieve the heaps for the specified process. If pHeapMap is set to NULL
-* the number of bytes required will be returned in parameter pcbHeapMap.
-* -- dwPID
-* -- pHeapMap = buffer of minimum byte length *pcbHeapMap or NULL.
-* -- pcbHeapMap = pointer to byte count of pHeapMap buffer.
-* -- return = success/fail.
-*/
-_Success_(return)
-BOOL VMMDLL_ProcessMap_GetHeap(_In_ DWORD dwPID, _Out_writes_bytes_opt_(*pcbHeapMap) PVMMDLL_MAP_HEAP pHeapMap, _Inout_ PDWORD pcbHeapMap);
+#endif /* VMMYARA_SCAN_MEMORY_CALLBACK_DEFINED */
+    // =========== END SHARED STRUCTS WITH <vmmdll.h/vmmyara.h> ===========
 
-/*
-* Retrieve the threads for the specified process. If pThreadMap is set to NULL
-* the number of bytes required will be returned in parameter pcbThreadMap.
-* Entries returned are sorted on VMMDLL_MAP_THREADENTRY.dwTID
-* -- dwPID
-* -- pThreadMap = buffer of minimum byte length *pcbThreadMap or NULL.
-* -- pcbThreadMap = pointer to byte count of pThreadMap buffer.
-* -- return = success/fail.
-*/
-_Success_(return)
-BOOL VMMDLL_ProcessMap_GetThread(_In_ DWORD dwPID, _Out_writes_bytes_opt_(*pcbThreadMap) PVMMDLL_MAP_THREAD pThreadMap, _Inout_ PDWORD pcbThreadMap);
+#define VMMDLL_YARA_CONFIG_VERSION                  0xdec30001
+#define VMMDLL_YARA_MEMORY_CALLBACK_CONTEXT_VERSION 0xdec40002
+#define VMMDLL_YARA_CONFIG_MAX_RESULT               0x00010000      // max 65k results.
 
-/*
-* Retrieve the handles for the specified process. If pHandleMap is set to NULL
-* the number of bytes required will be returned in parameter pcbHandleMap.
-* Entries returned are sorted on VMMDLL_MAP_HANDLEENTRY.dwHandle
-* -- dwPID
-* -- pHandleMap = buffer of minimum byte length *pcbHandleMap or NULL.
-* -- pcbHandleMap = pointer to byte count of pHandleMap buffer.
-* -- return = success/fail.
-*/
-_Success_(return)
-BOOL VMMDLL_ProcessMap_GetHandle(_In_ DWORD dwPID, _Out_writes_bytes_opt_(*pcbHandleMap) PVMMDLL_MAP_HANDLE pHandleMap, _Inout_ PDWORD pcbHandleMap);
+    typedef struct tdVMMDLL_YARA_CONFIG* PVMMDLL_YARA_CONFIG;           // forward declaration.
 
-/*
-* Retrieve the physical memory ranges from the physical memory map that Windows
-* have enumerated.
-* -- pPhysMemMap = buffer of minimum byte length *pcbPhysMemMap or NULL.
-* -- pcbPhysMemMap = pointer to byte count of pPhysMemMap buffer.
-* -- return = success/fail.
-*/
-_Success_(return)
-BOOL VMMDLL_Map_GetPhysMem(_Out_writes_bytes_opt_(*pcbPhysMemMap) PVMMDLL_MAP_PHYSMEM pPhysMemMap, _Inout_ PDWORD pcbPhysMemMap);
+    /*
+    * Callback function to tell whether a section of memory should be scanned or not.
+    * -- ctx = pointer to PVMMDLL_YARA_CONFIG context.
+    * -- pePte = pointer to PTE entry if the memory region is backed by PTE map. Otherwise NULL.
+    * -- peVad = pointer to VAD entry if the memory region is backed by VAD map. Otherwise NULL.
+    * -- return = return TRUE to scan the memory region, FALSE to skip it.
+    */
+    typedef BOOL(*VMMYARA_SCAN_FILTER_CALLBACK)(
+        _In_ PVMMDLL_YARA_CONFIG ctx,
+        _In_opt_ PVMMDLL_MAP_PTEENTRY pePte,
+        _In_opt_ PVMMDLL_MAP_VADENTRY peVad
+        );
 
-/*
-* Retrieve the non well known users that are detected in the target system.
-* NB! There may be more users in the system than the ones that are detected,
-* only users with mounted registry hives may currently be detected - this is
-* the normal behaviour for users with active processes.
-* -- pUserMap = buffer of minimum byte length *pcbUserMap or NULL.
-* -- pcbUserMap = pointer to byte count of pUserMap buffer.
-* -- return = success/fail.
-*/
-_Success_(return)
-BOOL VMMDLL_Map_GetUsers(_Out_writes_bytes_opt_(*pcbUserMap) PVMMDLL_MAP_USER pUserMap, _Inout_ PDWORD pcbUserMap);
+    /*
+    * Yara search configuration struct.
+    */
+    typedef struct tdVMMDLL_YARA_CONFIG {
+        DWORD dwVersion;            // VMMDLL_YARA_CONFIG_VERSION
+        DWORD _Filler[2];
+        BOOL fAbortRequested;       // may be set by caller to abort processing prematurely.
+        DWORD cMaxResult;           // # max result entries. max 0x10000 entries. 0 = max entries.
+        DWORD cRules;               // number of rules to use - if compiled rules only 1 is allowed.
+        LPSTR* pszRules;            // array of rules to use - either filenames or in-memory rules.
+        QWORD vaMin;
+        QWORD vaMax;
+        QWORD vaCurrent;            // current address (may be read by caller).
+        DWORD _Filler2;
+        DWORD cResult;              // number of search hits.
+        QWORD cbReadTotal;          // total number of bytes read.
+        PVOID pvUserPtrOpt;         // optional pointer set by caller (used for context passing to callbacks)
+        // match callback function (recommended but optional).
+        // return = continue search(TRUE), abort search(FALSE).
+        VMMYARA_SCAN_MEMORY_CALLBACK pfnScanMemoryCB;
+        // non-recommended features:
+        QWORD ReadFlags;            // read flags as in VMMDLL_FLAG_*
+        BOOL fForcePTE;             // force PTE method for virtual address reads.
+        BOOL fForceVAD;             // force VAD method for virtual address reads.
+        // optional filter callback function for virtual address reads:
+        // for ranges inbetween vaMin:vaMax callback with pte or vad entry.
+        // return: read from range(TRUE), do not read from range(FALSE).
+        VMMYARA_SCAN_FILTER_CALLBACK pfnFilterOptCB;
+        PVOID pvUserPtrOpt2;        // optional pointer set by caller (not used by MemProcFS).
+        QWORD _Reserved;
+    } VMMDLL_YARA_CONFIG, * PVMMDLL_YARA_CONFIG;
+
+    /*
+    * Yara search callback struct which created by MemProcFS internally and is
+    * passed to the callback function supplied by the caller in VMMDLL_YaraSearch().
+    */
+    typedef struct tdVMMDLL_YARA_MEMORY_CALLBACK_CONTEXT {
+        DWORD dwVersion;
+        DWORD dwPID;
+        PVOID pUserContext;
+        QWORD vaObject;
+        QWORD va;
+        PBYTE pb;
+        DWORD cb;
+        LPSTR uszTag[1];    // min 1 char (but may be more).
+    } VMMDLL_YARA_MEMORY_CALLBACK_CONTEXT, * PVMMDLL_YARA_MEMORY_CALLBACK_CONTEXT;
+
+    /*
+    * Perform a yara search in the address space of a process.
+    * NB! it may take a long time for this function to return.
+    * -- hVMM
+    * -- dwPID - PID of target process, (DWORD)-1 to read physical memory.
+    * -- pYaraConfig
+    * -- ppva = pointer to receive addresses found. Free'd with VMMDLL_MemFree().
+    * -- pcva = pointer to receive number of addresses in ppva. not bytes!
+    * -- return
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_YaraSearch(
+            _In_ VMM_HANDLE hVMM,
+            _In_ DWORD dwPID,
+            _In_ PVMMDLL_YARA_CONFIG pYaraConfig,
+            _Out_opt_ PQWORD* ppva,
+            _Out_opt_ PDWORD pcva
+        );
 
 
 
-//-----------------------------------------------------------------------------
-// WINDOWS SPECIFIC PAGE FRAME NUMBER (PFN) FUNCTIONALITY BELOW
-//-----------------------------------------------------------------------------
+    //-----------------------------------------------------------------------------
+    // WINDOWS SPECIFIC PAGE FRAME NUMBER (PFN) FUNCTIONALITY BELOW
+    //-----------------------------------------------------------------------------
 
 #define VMMDLL_MAP_PFN_VERSION              1
 
-static LPCSTR VMMDLL_PFN_TYPE_TEXT[] = { "Zero", "Free", "Standby", "Modifiy", "ModNoWr", "Bad", "Active", "Transit" };
-static LPCSTR VMMDLL_PFN_TYPEEXTENDED_TEXT[] = { "-", "Unused", "ProcPriv", "PageTable", "LargePage", "DriverLock", "Shareable", "File" };
+#define VMMDLL_PFN_FLAG_NORMAL              0
+#define VMMDLL_PFN_FLAG_EXTENDED            1
 
-typedef enum tdVMMDLL_MAP_PFN_TYPE {
-    VmmDll_PfnTypeZero = 0,
-    VmmDll_PfnTypeFree = 1,
-    VmmDll_PfnTypeStandby = 2,
-    VmmDll_PfnTypeModified = 3,
-    VmmDll_PfnTypeModifiedNoWrite = 4,
-    VmmDll_PfnTypeBad = 5,
-    VmmDll_PfnTypeActive = 6,
-    VmmDll_PfnTypeTransition = 7
-} VMMDLL_MAP_PFN_TYPE;
+    static LPCSTR VMMDLL_PFN_TYPE_TEXT[] = { "Zero", "Free", "Standby", "Modifiy", "ModNoWr", "Bad", "Active", "Transit" };
+    static LPCSTR VMMDLL_PFN_TYPEEXTENDED_TEXT[] = { "-", "Unused", "ProcPriv", "PageTable", "LargePage", "DriverLock", "Shareable", "File" };
 
-typedef enum tdVMMDLL_MAP_PFN_TYPEEXTENDED {
-    VmmDll_PfnExType_Unknown = 0,
-    VmmDll_PfnExType_Unused = 1,
-    VmmDll_PfnExType_ProcessPrivate = 2,
-    VmmDll_PfnExType_PageTable = 3,
-    VmmDll_PfnExType_LargePage = 4,
-    VmmDll_PfnExType_DriverLocked = 5,
-    VmmDll_PfnExType_Shareable = 6,
-    VmmDll_PfnExType_File = 7,
-} VMMDLL_MAP_PFN_TYPEEXTENDED;
+    typedef enum tdVMMDLL_MAP_PFN_TYPE {
+        VmmDll_PfnTypeZero = 0,
+        VmmDll_PfnTypeFree = 1,
+        VmmDll_PfnTypeStandby = 2,
+        VmmDll_PfnTypeModified = 3,
+        VmmDll_PfnTypeModifiedNoWrite = 4,
+        VmmDll_PfnTypeBad = 5,
+        VmmDll_PfnTypeActive = 6,
+        VmmDll_PfnTypeTransition = 7
+    } VMMDLL_MAP_PFN_TYPE;
 
-typedef struct tdVMMDLL_MAP_PFNENTRY {
-    DWORD dwPfn;
-    VMMDLL_MAP_PFN_TYPEEXTENDED tpExtended;
-    struct {        // Only valid if active non-prototype PFN
+    typedef enum tdVMMDLL_MAP_PFN_TYPEEXTENDED {
+        VmmDll_PfnExType_Unknown = 0,
+        VmmDll_PfnExType_Unused = 1,
+        VmmDll_PfnExType_ProcessPrivate = 2,
+        VmmDll_PfnExType_PageTable = 3,
+        VmmDll_PfnExType_LargePage = 4,
+        VmmDll_PfnExType_DriverLocked = 5,
+        VmmDll_PfnExType_Shareable = 6,
+        VmmDll_PfnExType_File = 7,
+    } VMMDLL_MAP_PFN_TYPEEXTENDED;
+
+    typedef struct tdVMMDLL_MAP_PFNENTRY {
+        DWORD dwPfn;
+        VMMDLL_MAP_PFN_TYPEEXTENDED tpExtended;
+        struct {        // Only valid if active non-prototype PFN
+            union {
+                DWORD dwPid;
+                DWORD dwPfnPte[5];  // PFN of paging levels 1-4 (x64)
+            };
+            QWORD va;               // valid if non-zero
+        } AddressInfo;
+        QWORD vaPte;
+        QWORD OriginalPte;
         union {
-            DWORD dwPid;
-            DWORD dwPfnPte[5];  // PFN of paging levels 1-4 (x64)
+            DWORD _u3;
+            struct {
+                WORD ReferenceCount;
+                // MMPFNENTRY
+                BYTE PageLocation : 3;    // Pos 0  - VMMDLL_MAP_PFN_TYPE
+                BYTE WriteInProgress : 1;    // Pos 3
+                BYTE Modified : 1;    // Pos 4
+                BYTE ReadInProgress : 1;    // Pos 5
+                BYTE CacheAttribute : 2;    // Pos 6
+                BYTE Priority : 3;    // Pos 0
+                BYTE Rom_OnProtectedStandby : 1;// Pos 3
+                BYTE InPageError : 1;    // Pos 4
+                BYTE KernelStack_SystemChargedPage : 1; // Pos 5
+                BYTE RemovalRequested : 1;    // Pos 6
+                BYTE ParityError : 1;    // Pos 7
+            };
         };
-        QWORD va;               // valid if non-zero
-    } AddressInfo;
-    QWORD vaPte;
-    QWORD OriginalPte;
-    union {
-        DWORD _u3;
-        struct {
-            WORD ReferenceCount;
-            // MMPFNENTRY
-            BYTE PageLocation       : 3;    // Pos 0  - VMMDLL_MAP_PFN_TYPE
-            BYTE WriteInProgress    : 1;    // Pos 3
-            BYTE Modified           : 1;    // Pos 4
-            BYTE ReadInProgress     : 1;    // Pos 5
-            BYTE CacheAttribute     : 2;    // Pos 6
-            BYTE Priority           : 3;    // Pos 0
-            BYTE Rom_OnProtectedStandby : 1;// Pos 3
-            BYTE InPageError        : 1;    // Pos 4
-            BYTE KernelStack_SystemChargedPage : 1; // Pos 5
-            BYTE RemovalRequested   : 1;    // Pos 6
-            BYTE ParityError        : 1;    // Pos 7
+        union {
+            QWORD _u4;
+            struct {
+                DWORD PteFrame;
+                DWORD PteFrameHigh : 4;    // Pos 32
+                DWORD _Reserved : 21;   // Pos 36
+                DWORD PrototypePte : 1;    // Pos 57
+                DWORD PageColor : 6;    // Pos 58
+            };
         };
-    };
-    union {
-        QWORD _u4;
-        struct {
-            DWORD PteFrame;
-            DWORD PteFrameHigh      : 4;    // Pos 32
-            DWORD _Reserved         : 21;   // Pos 36
-            DWORD PrototypePte      : 1;    // Pos 57
-            DWORD PageColor         : 6;    // Pos 58
-        };
-    };
-    DWORD _FutureUse[6];
-} VMMDLL_MAP_PFNENTRY, *PVMMDLL_MAP_PFNENTRY;
+        DWORD _FutureUse[6];
+    } VMMDLL_MAP_PFNENTRY, * PVMMDLL_MAP_PFNENTRY;
 
-typedef struct tdVMMDLL_MAP_PFN {
-    DWORD dwVersion;
-    DWORD _Reserved1[5];
-    DWORD cMap;                     // # map entries.
-    VMMDLL_MAP_PFNENTRY pMap[];     // map entries.
-} VMMDLL_MAP_PFN, *PVMMDLL_MAP_PFN;
+    typedef struct tdVMMDLL_MAP_PFN {
+        DWORD dwVersion;
+        DWORD _Reserved1[5];
+        DWORD cMap;                     // # map entries.
+        VMMDLL_MAP_PFNENTRY pMap[];     // map entries.
+    } VMMDLL_MAP_PFN, * PVMMDLL_MAP_PFN;
 
-/*
-* Retrieve information about scattered PFNs. The PFNs are returned in order of
-* in which they are stored in the pPfns set.
-* -- pPfns
-* -- cPfns
-* -- pPfnMap = buffer of minimum byte length *pcbPfnMap or NULL.
-* -- pcbPfnMap = pointer to byte count of pPhysMemMap buffer.
-* -- return = success/fail.
-*/
-_Success_(return)
-BOOL VMMDLL_Map_GetPfn(_In_ DWORD pPfns[], _In_ DWORD cPfns, _Out_writes_bytes_opt_(*pcbPfnMap) PVMMDLL_MAP_PFN pPfnMap, _Inout_ PDWORD pcbPfnMap);
+    /*
+    * Retrieve information about scattered PFNs. The PFNs are returned in order of
+    * in which they are stored in the pPfns set.
+    * -- hVMM
+    * -- pPfns
+    * -- cPfns
+    * -- pPfnMap = buffer of minimum byte length *pcbPfnMap or NULL.
+    * -- pcbPfnMap = pointer to byte count of pPhysMemMap buffer.
+    * -- return = success/fail.
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_Map_GetPfn(
+            _In_ VMM_HANDLE hVMM,
+            _In_reads_(cPfns) DWORD pPfns[],
+            _In_ DWORD cPfns,
+            _Out_writes_bytes_opt_(*pcbPfnMap) PVMMDLL_MAP_PFN pPfnMap,
+            _Inout_ PDWORD pcbPfnMap
+        );
+
+    /*
+    * Retrieve PFN information:
+    * CALLER FREE: VMMDLL_MemFree(*ppPfnMap)
+    * -- hVMM
+    * -- pPfns = PFNs to retrieve.
+    * -- cPfns = number of PFNs to retrieve.
+    * -- ppPfnMap =  ptr to receive result on success. must be free'd with VMMDLL_MemFree().
+    * -- flags = optional flags as specified by VMMDLL_PFN_FLAG_*
+    * -- return = success/fail.
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_Map_GetPfnEx(
+            _In_ VMM_HANDLE hVMM,
+            _In_reads_(cPfns) DWORD pPfns[],
+            _In_ DWORD cPfns,
+            _Out_ PVMMDLL_MAP_PFN* ppPfnMap,
+            _In_ DWORD flags
+        );
 
 
 
-//-----------------------------------------------------------------------------
-// VMM PROCESS FUNCTIONALITY BELOW:
-// Functionality below is mostly relating to Windows processes.
-//-----------------------------------------------------------------------------
+    //-----------------------------------------------------------------------------
+    // VMM PROCESS FUNCTIONALITY BELOW:
+    // Functionality below is mostly relating to Windows processes.
+    //-----------------------------------------------------------------------------
 
-/*
-* Retrieve an active process given it's name. Please note that if multiple
-* processes with the same name exists only one will be returned. If required to
-* parse all processes with the same name please iterate over the PID list by
-* calling VMMDLL_PidList together with VMMDLL_ProcessGetInformation.
-* -- szProcName = process name case insensitive.
-* -- pdwPID = pointer that will receive PID on success.
-* -- return
-*/
-_Success_(return)
-BOOL VMMDLL_PidGetFromName(_In_ LPSTR szProcName, _Out_ PDWORD pdwPID);
+    /*
+    * Retrieve an active process given it's name. Please note that if multiple
+    * processes with the same name exists only one will be returned. If required to
+    * parse all processes with the same name please iterate over the PID list by
+    * calling VMMDLL_PidList together with VMMDLL_ProcessGetInformation.
+    * -- hVMM
+    * -- szProcName = process name case insensitive.
+    * -- pdwPID = pointer that will receive PID on success.
+    * -- return
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_PidGetFromName(_In_ VMM_HANDLE hVMM, _In_ LPSTR szProcName, _Out_ PDWORD pdwPID);
 
-/*
-* List the PIDs in the system.
-* -- pPIDs = DWORD array of at least number of PIDs in system, or NULL.
-* -- pcPIDs = size of (in number of DWORDs) pPIDs array on entry, number of PIDs in system on exit.
-* -- return = success/fail.
-*/
-_Success_(return)
-BOOL VMMDLL_PidList(_Out_writes_opt_(*pcPIDs) PDWORD pPIDs, _Inout_ PULONG64 pcPIDs); 
+    /*
+    * List the PIDs in the system.
+    * -- hVMM
+    * -- pPIDs = DWORD array of at least number of PIDs in system, or NULL.
+    * -- pcPIDs = size of (in number of DWORDs) pPIDs array on entry, number of PIDs in system on exit.
+    * -- return = success/fail.
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_PidList(_In_ VMM_HANDLE hVMM, _Out_writes_opt_(*pcPIDs) PDWORD pPIDs, _Inout_ PSIZE_T pcPIDs);
 
 #define VMMDLL_PROCESS_INFORMATION_MAGIC        0xc0ffee663df9301e
-#define VMMDLL_PROCESS_INFORMATION_VERSION      6
+#define VMMDLL_PROCESS_INFORMATION_VERSION      7
 
-typedef struct tdVMMDLL_PROCESS_INFORMATION {
-    ULONG64 magic;
-    WORD wVersion;
-    WORD wSize;
-    VMMDLL_MEMORYMODEL_TP tpMemoryModel;    // as given by VMMDLL_MEMORYMODEL_* enum
-    VMMDLL_SYSTEM_TP tpSystem;              // as given by VMMDLL_SYSTEM_* enum
-    BOOL fUserOnly;                         // only user mode pages listed
-    DWORD dwPID;
-    DWORD dwPPID;
-    DWORD dwState;
-    CHAR szName[16];
-    CHAR szNameLong[64];
-    ULONG64 paDTB;
-    ULONG64 paDTB_UserOpt;                  // may not exist
-    struct {
-        ULONG64 vaEPROCESS;
-        ULONG64 vaPEB;
-        ULONG64 _Reserved1;
-        BOOL fWow64;
-        DWORD vaPEB32;                  // WoW64 only
-        DWORD dwSessionId;
-        ULONG64 qwLUID;
-        CHAR szSID[MAX_PATH];
-    } win;
-} VMMDLL_PROCESS_INFORMATION, *PVMMDLL_PROCESS_INFORMATION;
+    typedef enum tdVMMDLL_PROCESS_INTEGRITY_LEVEL {
+        VMMDLL_PROCESS_INTEGRITY_LEVEL_UNKNOWN = 0,
+        VMMDLL_PROCESS_INTEGRITY_LEVEL_UNTRUSTED = 1,
+        VMMDLL_PROCESS_INTEGRITY_LEVEL_LOW = 2,
+        VMMDLL_PROCESS_INTEGRITY_LEVEL_MEDIUM = 3,
+        VMMDLL_PROCESS_INTEGRITY_LEVEL_MEDIUMPLUS = 4,
+        VMMDLL_PROCESS_INTEGRITY_LEVEL_HIGH = 5,
+        VMMDLL_PROCESS_INTEGRITY_LEVEL_SYSTEM = 6,
+        VMMDLL_PROCESS_INTEGRITY_LEVEL_PROTECTED = 7,
+    } VMMDLL_PROCESS_INTEGRITY_LEVEL;
 
-/*
-* Retrieve various process information from a PID. Process information such as
-* name, page directory bases and the process state may be retrieved.
-* -- dwPID
-* -- pProcessInformation = if null, size is given in *pcbProcessInfo
-* -- pcbProcessInformation = size of pProcessInfo (in bytes) on entry and exit
-* -- return = success/fail.
-*/
-_Success_(return)
-BOOL VMMDLL_ProcessGetInformation(_In_ DWORD dwPID, _Inout_opt_ PVMMDLL_PROCESS_INFORMATION pProcessInformation, _In_ PSIZE_T pcbProcessInformation);
+    typedef struct tdVMMDLL_PROCESS_INFORMATION {
+        ULONG64 magic;
+        WORD wVersion;
+        WORD wSize;
+        VMMDLL_MEMORYMODEL_TP tpMemoryModel;    // as given by VMMDLL_MEMORYMODEL_* enum
+        VMMDLL_SYSTEM_TP tpSystem;              // as given by VMMDLL_SYSTEM_* enum
+        BOOL fUserOnly;                         // only user mode pages listed
+        DWORD dwPID;
+        DWORD dwPPID;
+        DWORD dwState;
+        CHAR szName[16];
+        CHAR szNameLong[64];
+        ULONG64 paDTB;
+        ULONG64 paDTB_UserOpt;                  // may not exist
+        struct {
+            ULONG64 vaEPROCESS;
+            ULONG64 vaPEB;
+            ULONG64 _Reserved1;
+            BOOL fWow64;
+            DWORD vaPEB32;                  // WoW64 only
+            DWORD dwSessionId;
+            ULONG64 qwLUID;
+            CHAR szSID[MAX_PATH];
+            VMMDLL_PROCESS_INTEGRITY_LEVEL IntegrityLevel;
+        } win;
+    } VMMDLL_PROCESS_INFORMATION, * PVMMDLL_PROCESS_INFORMATION;
+
+    /*
+    * Retrieve various process information from a PID. Process information such as
+    * name, page directory bases and the process state may be retrieved.
+    * -- hVMM
+    * -- dwPID
+    * -- pProcessInformation = if null, size is given in *pcbProcessInfo
+    * -- pcbProcessInformation = size of pProcessInfo (in bytes) on entry and exit
+    * -- return = success/fail.
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_ProcessGetInformation(
+            _In_ VMM_HANDLE hVMM,
+            _In_ DWORD dwPID,
+            _Inout_opt_ PVMMDLL_PROCESS_INFORMATION pProcessInformation,
+            _In_ PSIZE_T pcbProcessInformation
+        );
+
+    /*
+    * Retrieve various information from all processes (including terminated).
+    * CALLER FREE : VMMDLL_MemFree(*ppProcessInformationAll)
+    * -- hVMM
+    * -- ptr to receive result array of pcProcessInformation items on success.
+    *    Must be free'd with VMMDLL_MemFree().
+    * -- ptr to DWORD to receive number of items processes on success.
+    * -- return = success/fail.
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_ProcessGetInformationAll(
+            _In_ VMM_HANDLE hVMM,
+            _Out_ PVMMDLL_PROCESS_INFORMATION* ppProcessInformationAll,
+            _Out_ PDWORD pcProcessInformation
+        );
 
 #define VMMDLL_PROCESS_INFORMATION_OPT_STRING_PATH_KERNEL           1
 #define VMMDLL_PROCESS_INFORMATION_OPT_STRING_PATH_USER_IMAGE       2
 #define VMMDLL_PROCESS_INFORMATION_OPT_STRING_CMDLINE               3
 
-/*
-* Retrieve a string value belonging to a process. The function allocates a new
-* string buffer and returns the requested string in it. The string is always
-* NULL terminated. On failure NULL is returned.
-* NB! CALLER IS RESPONSIBLE FOR VMMDLL_MemFree return value!
-* CALLER FREE: VMMDLL_MemFree(return)
-* -- dwPID
-* -- fOptionString = string value to retrieve as given by VMMDLL_PROCESS_INFORMATION_OPT_STRING_*
-* -- return - fail: NULL, success: the string - NB! must be VMMDLL_MemFree'd by caller!
-*/
-LPSTR VMMDLL_ProcessGetInformationString(_In_ DWORD dwPID, _In_ DWORD fOptionString);
+    /*
+    * Retrieve a string value belonging to a process. The function allocates a new
+    * string buffer and returns the requested string in it. The string is always
+    * NULL terminated. On failure NULL is returned.
+    * NB! CALLER IS RESPONSIBLE FOR VMMDLL_MemFree return value!
+    * CALLER FREE: VMMDLL_MemFree(return)
+    * -- hVMM
+    * -- dwPID
+    * -- fOptionString = string value to retrieve as given by VMMDLL_PROCESS_INFORMATION_OPT_STRING_*
+    * -- return - fail: NULL, success: the string - NB! must be VMMDLL_MemFree'd by caller!
+    */
+    EXPORTED_FUNCTION _Success_(return != NULL)
+        LPSTR VMMDLL_ProcessGetInformationString(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_ DWORD fOptionString);
 
-typedef struct tdVMMDLL_EAT_ENTRY {
-    ULONG64 vaFunction;
-    DWORD vaFunctionOffset;
-    CHAR szFunction[40];
-} VMMDLL_EAT_ENTRY, *PVMMDLL_EAT_ENTRY;
+    /*
+    * Retrieve information about: Data Directories, Sections, Export Address Table
+    * and Import Address Table (IAT).
+    * If the pData == NULL upon entry the number of entries of the pData array must
+    * have in order to be able to hold the data is returned.
+    * -- hVMM
+    * -- dwPID
+    * -- [uw]szModule
+    * -- pData
+    * -- cData
+    * -- pcData
+    * -- return = success/fail.
+    */
+    EXPORTED_FUNCTION
+        _Success_(return) BOOL VMMDLL_ProcessGetDirectoriesU(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_ LPSTR  uszModule, _Out_writes_(16) PIMAGE_DATA_DIRECTORY pDataDirectories);
+    _Success_(return) BOOL VMMDLL_ProcessGetDirectoriesW(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_ LPWSTR wszModule, _Out_writes_(16) PIMAGE_DATA_DIRECTORY pDataDirectories);
+    EXPORTED_FUNCTION
+        _Success_(return) BOOL VMMDLL_ProcessGetSectionsU(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_ LPSTR  uszModule, _Out_writes_opt_(cSections) PIMAGE_SECTION_HEADER pSections, _In_ DWORD cSections, _Out_ PDWORD pcSections);
+    _Success_(return) BOOL VMMDLL_ProcessGetSectionsW(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_ LPWSTR wszModule, _Out_writes_opt_(cSections) PIMAGE_SECTION_HEADER pSections, _In_ DWORD cSections, _Out_ PDWORD pcSections);
 
-typedef struct tdVMMDLL_IAT_ENTRY {
-    ULONG64 vaFunction;
-    CHAR szFunction[40];
-    CHAR szModule[64];
-} VMMDLL_IAT_ENTRY, *PVMMDLL_IAT_ENTRY;
+    /*
+    * Retrieve the virtual address of a given function inside a process/module.
+    * -- hVMM
+    * -- dwPID
+    * -- [uw]szModuleName
+    * -- szFunctionName
+    * -- return = virtual address of function, zero on fail.
+    */
+    EXPORTED_FUNCTION
+        _Success_(return != 0) ULONG64 VMMDLL_ProcessGetProcAddressU(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_ LPSTR  uszModuleName, _In_ LPSTR szFunctionName);
+    _Success_(return != 0) ULONG64 VMMDLL_ProcessGetProcAddressW(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_ LPWSTR wszModuleName, _In_ LPSTR szFunctionName);
 
-/*
-* Retrieve information about: Data Directories, Sections, Export Address Table
-* and Import Address Table (IAT).
-* If the pData == NULL upon entry the number of entries of the pData array must
-* have in order to be able to hold the data is returned.
-* -- dwPID
-* -- wszModule
-* -- pData
-* -- cData
-* -- pcData
-* -- return = success/fail.
-*/
-_Success_(return) 
-BOOL VMMDLL_ProcessGetDirectories(_In_ DWORD dwPID, _In_ LPWSTR wszModule, _Out_writes_(16) PIMAGE_DATA_DIRECTORY pData, _In_ DWORD cData, _Out_ PDWORD pcData);
-_Success_(return)
-BOOL VMMDLL_ProcessGetSections(_In_ DWORD dwPID, _In_ LPWSTR wszModule, _Out_opt_ PIMAGE_SECTION_HEADER pData, _In_ DWORD cData, _Out_ PDWORD pcData);
-_Success_(return)
-BOOL VMMDLL_ProcessGetEAT(_In_ DWORD dwPID, _In_ LPWSTR wszModule, _Out_opt_ PVMMDLL_EAT_ENTRY pData, _In_ DWORD cData, _Out_ PDWORD pcData);
-_Success_(return)
-BOOL VMMDLL_ProcessGetIAT(_In_ DWORD dwPID, _In_ LPWSTR wszModule, _Out_opt_ PVMMDLL_IAT_ENTRY pData, _In_ DWORD cData, _Out_ PDWORD pcData);
-
-/*
-* Retrieve the virtual address of a given function inside a process/module.
-* -- dwPID
-* -- wszModuleName
-* -- szFunctionName
-* -- return = virtual address of function, zero on fail.
-*/
-ULONG64 VMMDLL_ProcessGetProcAddress(_In_ DWORD dwPID, _In_ LPWSTR wszModuleName, _In_ LPSTR szFunctionName);
-
-/*
-* Retrieve the base address of a given module.
-* -- dwPID
-* -- wszModuleName
-* -- return = virtual address of module base, zero on fail.
-*/
-ULONG64 VMMDLL_ProcessGetModuleBase(_In_ DWORD dwPID, _In_ LPWSTR wszModuleName);
+    /*
+    * Retrieve the base address of a given module.
+    * -- hVMM
+    * -- dwPID
+    * -- [uw]szModuleName
+    * -- return = virtual address of module base, zero on fail.
+    */
+    EXPORTED_FUNCTION
+        _Success_(return != 0) ULONG64 VMMDLL_ProcessGetModuleBaseU(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_ LPSTR  uszModuleName);
+    _Success_(return != 0) ULONG64 VMMDLL_ProcessGetModuleBaseW(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_ LPWSTR wszModuleName);
 
 
 
-//-----------------------------------------------------------------------------
-// WINDOWS SPECIFIC DEBUGGING / SYMBOL FUNCTIONALITY BELOW:
-//-----------------------------------------------------------------------------
+    //-----------------------------------------------------------------------------
+    // WINDOWS SPECIFIC DEBUGGING / SYMBOL FUNCTIONALITY BELOW:
+    //-----------------------------------------------------------------------------
 
-/*
-* Retrieve a symbol virtual address given a module name and a symbol name.
-* NB! not all modules may exist - initially only module "nt" is available.
-* NB! if multiple modules have the same name the 1st to be added will be used.
-* -- szModule
-* -- szSymbolName
-* -- pvaSymbolAddress
-* -- return
-*/
-_Success_(return)
-BOOL VMMDLL_PdbSymbolAddress(_In_ LPSTR szModule, _In_ LPSTR szSymbolName, _Out_ PULONG64 pvaSymbolAddress);
+    /*
+    * Load a .pdb symbol file and return its associated module name upon success.
+    * -- hVMM
+    * -- dwPID
+    * -- vaModuleBase
+    * -- szModuleName = buffer to receive module name upon success.
+    * -- return
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_PdbLoad(
+            _In_ VMM_HANDLE hVMM,
+            _In_ DWORD dwPID,
+            _In_ ULONG64 vaModuleBase,
+            _Out_writes_(MAX_PATH) LPSTR szModuleName
+        );
 
-/*
-* Retrieve a type size given a module name and a type name.
-* NB! not all modules may exist - initially only module "nt" is available.
-* NB! if multiple modules have the same name the 1st to be added will be used.
-* -- szModule
-* -- szTypeName
-* -- pcbTypeSize
-* -- return
-*/
-_Success_(return)
-BOOL VMMDLL_PdbTypeSize(_In_ LPSTR szModule, _In_ LPSTR szTypeName, _Out_ PDWORD pcbTypeSize);
+    /*
+    * Retrieve a symbol virtual address given a module name and a symbol name.
+    * NB! not all modules may exist - initially only module "nt" is available.
+    * NB! if multiple modules have the same name the 1st to be added will be used.
+    * -- hVMM
+    * -- szModule
+    * -- cbSymbolAddressOrOffset = symbol virtual address or symbol offset.
+    * -- szSymbolName = buffer to receive symbol name upon success.
+    * -- pdwSymbolDisplacement = displacement from the beginning of the symbol.
+    * -- return
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_PdbSymbolName(
+            _In_ VMM_HANDLE hVMM,
+            _In_ LPSTR szModule,
+            _In_ QWORD cbSymbolAddressOrOffset,
+            _Out_writes_(MAX_PATH) LPSTR szSymbolName,
+            _Out_opt_ PDWORD pdwSymbolDisplacement
+        );
 
-/*
-* Locate the offset of a type child - typically a sub-item inside a struct.
-* NB! not all modules may exist - initially only module "nt" is available.
-* NB! if multiple modules have the same name the 1st to be added will be used.
-* -- szModule
-* -- szTypeName
-* -- wszTypeChildName
-* -- pcbTypeChildOffset
-* -- return
-*/
-_Success_(return)
-BOOL VMMDLL_PdbTypeChildOffset(_In_ LPSTR szModule, _In_ LPSTR szTypeName, _In_ LPWSTR wszTypeChildName, _Out_ PDWORD pcbTypeChildOffset);
+    /*
+    * Retrieve a symbol virtual address given a module name and a symbol name.
+    * NB! not all modules may exist - initially only module "nt" is available.
+    * NB! if multiple modules have the same name the 1st to be added will be used.
+    * -- hVMM
+    * -- szModule
+    * -- szSymbolName
+    * -- pvaSymbolAddress
+    * -- return
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_PdbSymbolAddress(
+            _In_ VMM_HANDLE hVMM,
+            _In_ LPSTR szModule,
+            _In_ LPSTR szSymbolName,
+            _Out_ PULONG64 pvaSymbolAddress
+        );
+
+    /*
+    * Retrieve a type size given a module name and a type name.
+    * NB! not all modules may exist - initially only module "nt" is available.
+    * NB! if multiple modules have the same name the 1st to be added will be used.
+    * -- hVMM
+    * -- szModule
+    * -- szTypeName
+    * -- pcbTypeSize
+    * -- return
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_PdbTypeSize(
+            _In_ VMM_HANDLE hVMM,
+            _In_ LPSTR szModule,
+            _In_ LPSTR szTypeName,
+            _Out_ PDWORD pcbTypeSize
+        );
+
+    /*
+    * Locate the offset of a type child - typically a sub-item inside a struct.
+    * NB! not all modules may exist - initially only module "nt" is available.
+    * NB! if multiple modules have the same name the 1st to be added will be used.
+    * -- hVMM
+    * -- szModule
+    * -- uszTypeName
+    * -- uszTypeChildName
+    * -- pcbTypeChildOffset
+    * -- return
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_PdbTypeChildOffset(
+            _In_ VMM_HANDLE hVMM,
+            _In_ LPSTR szModule,
+            _In_ LPSTR uszTypeName,
+            _In_ LPSTR uszTypeChildName,
+            _Out_ PDWORD pcbTypeChildOffset
+        );
 
 
 
-//-----------------------------------------------------------------------------
-// WINDOWS SPECIFIC REGISTRY FUNCTIONALITY BELOW:
-//-----------------------------------------------------------------------------
+    //-----------------------------------------------------------------------------
+    // WINDOWS SPECIFIC REGISTRY FUNCTIONALITY BELOW:
+    //-----------------------------------------------------------------------------
 
 #define VMMDLL_REGISTRY_HIVE_INFORMATION_MAGIC      0xc0ffee653df8d01e
-#define VMMDLL_REGISTRY_HIVE_INFORMATION_VERSION    2
+#define VMMDLL_REGISTRY_HIVE_INFORMATION_VERSION    4
 
-typedef struct td_VMMDLL_REGISTRY_HIVE_INFORMATION {
-    ULONG64 magic;
-    WORD wVersion;
-    WORD wSize;
-    BYTE _FutureReserved1[0x14];
-    ULONG64 vaCMHIVE;
-    ULONG64 vaHBASE_BLOCK;
-    DWORD cbLength;
-    CHAR szName[128];
-    WCHAR wszNameShort[32 + 1];
-    WCHAR wszHiveRootPath[MAX_PATH];
-    QWORD _FutureReserved[0x10];
-} VMMDLL_REGISTRY_HIVE_INFORMATION, *PVMMDLL_REGISTRY_HIVE_INFORMATION;
+    typedef struct td_VMMDLL_REGISTRY_HIVE_INFORMATION {
+        ULONG64 magic;
+        WORD wVersion;
+        WORD wSize;
+        BYTE _FutureReserved1[0x34];
+        ULONG64 vaCMHIVE;
+        ULONG64 vaHBASE_BLOCK;
+        DWORD cbLength;
+        CHAR uszName[128];
+        CHAR uszNameShort[32 + 1];
+        CHAR uszHiveRootPath[MAX_PATH];
+        QWORD _FutureReserved[0x10];
+    } VMMDLL_REGISTRY_HIVE_INFORMATION, * PVMMDLL_REGISTRY_HIVE_INFORMATION;
 
-/*
-* Retrieve information about the registry hives in the target system.
-* -- pHives = buffer of cHives * sizeof(VMMDLL_REGISTRY_HIVE_INFORMATION) to receive information about all hives. NULL to receive # hives in pcHives.
-* -- cHives
-* -- pcHives = if pHives == NULL: # total hives. if pHives: # read hives.
-* -- return
-*/
-_Success_(return)
-BOOL VMMDLL_WinReg_HiveList(_Out_writes_(cHives) PVMMDLL_REGISTRY_HIVE_INFORMATION pHives, _In_ DWORD cHives, _Out_ PDWORD pcHives);
+    /*
+    * Retrieve information about the registry hives in the target system.
+    * -- pHives = buffer of cHives * sizeof(VMMDLL_REGISTRY_HIVE_INFORMATION) to
+                  receive info about all hives. NULL to receive # hives in pcHives.
+    * -- cHives
+    * -- pcHives = if pHives == NULL: # total hives. if pHives: # read hives.
+    * -- return
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_WinReg_HiveList(
+            _In_ VMM_HANDLE hVMM,
+            _Out_writes_(cHives) PVMMDLL_REGISTRY_HIVE_INFORMATION pHives,
+            _In_ DWORD cHives,
+            _Out_ PDWORD pcHives
+        );
 
-/*
-* Read a contigious arbitrary amount of registry hive memory and report the
-* number of bytes read in pcbRead.
-* NB! Address space does not include regf registry hive file header!
-* -- vaCMHive
-* -- ra
-* -- pb
-* -- cb
-* -- pcbReadOpt
-* -- flags = flags as in VMMDLL_FLAG_*
-* -- return = success/fail. NB! reads may report as success even if 0 bytes are
-*        read - it's recommended to verify pcbReadOpt parameter.
-*/
-_Success_(return)
-BOOL VMMDLL_WinReg_HiveReadEx(_In_ ULONG64 vaCMHive, _In_ DWORD ra, _Out_ PBYTE pb, _In_ DWORD cb, _Out_opt_ PDWORD pcbReadOpt, _In_ ULONG64 flags);
+    /*
+    * Read a contigious arbitrary amount of registry hive memory and report the
+    * number of bytes read in pcbRead.
+    * NB! Address space does not include regf registry hive file header!
+    * -- hVMM
+    * -- vaCMHive
+    * -- ra
+    * -- pb
+    * -- cb
+    * -- pcbReadOpt
+    * -- flags = flags as in VMMDLL_FLAG_*
+    * -- return = success/fail. NB! reads may report as success even if 0 bytes are
+    *        read - it's recommended to verify pcbReadOpt parameter.
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_WinReg_HiveReadEx(
+            _In_ VMM_HANDLE hVMM,
+            _In_ ULONG64 vaCMHive,
+            _In_ DWORD ra,
+            _Out_ PBYTE pb,
+            _In_ DWORD cb,
+            _Out_opt_ PDWORD pcbReadOpt,
+            _In_ ULONG64 flags
+        );
 
-/*
-* Write a virtually contigious arbitrary amount of memory to a registry hive.
-* NB! Address space does not include regf registry hive file header!
-* -- vaCMHive
-* -- ra
-* -- pb
-* -- cb
-* -- return = TRUE on success, FALSE on partial or zero write.
-*/
-_Success_(return)
-BOOL VMMDLL_WinReg_HiveWrite(_In_ ULONG64 vaCMHive, _In_ DWORD ra, _In_ PBYTE pb, _In_ DWORD cb);
+    /*
+    * Write a virtually contigious arbitrary amount of memory to a registry hive.
+    * NB! Address space does not include regf registry hive file header!
+    * -- hVMM
+    * -- vaCMHive
+    * -- ra
+    * -- pb
+    * -- cb
+    * -- return = TRUE on success, FALSE on partial or zero write.
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_WinReg_HiveWrite(
+            _In_ VMM_HANDLE hVMM,
+            _In_ ULONG64 vaCMHive,
+            _In_ DWORD ra,
+            _In_ PBYTE pb,
+            _In_ DWORD cb
+        );
 
-/*
-* Enumerate registry sub keys - similar to WINAPI function 'RegEnumKeyExW.'
-* Please consult WINAPI function documentation for information.
-* May be called with HKLM base or virtual address of CMHIVE base examples:
-*   1) 'HKLM\SOFTWARE\Key\SubKey'
-*   2) 'HKLM\ORPHAN\SAM\Key\SubKey'              (orphan key)
-*   3) '0x<vaCMHIVE>\ROOT\Key\SubKey'
-*   4) '0x<vaCMHIVE>\ORPHAN\Key\SubKey'          (orphan key)
-* -- wszFullPathKey
-* -- dwIndex
-* -- lpName
-* -- lpcchName
-* -- lpftLastWriteTime
-* -- return
-*/
-_Success_(return)
-BOOL VMMDLL_WinReg_EnumKeyExW(
-    _In_ LPWSTR wszFullPathKey,
-    _In_ DWORD dwIndex,
-    _Out_writes_opt_(*lpcchName) LPWSTR lpName,
-    _Inout_ LPDWORD lpcchName,
-    _Out_opt_ PFILETIME lpftLastWriteTime
-);
+    /*
+    * Enumerate registry sub keys - similar to WINAPI function 'RegEnumKeyExW.'
+    * Please consult WINAPI function documentation for information.
+    * May be called with HKLM base or virtual address of CMHIVE base examples:
+    *   1) 'HKLM\SOFTWARE\Key\SubKey'
+    *   2) 'HKLM\ORPHAN\SAM\Key\SubKey'              (orphan key)
+    *   3) '0x<vaCMHIVE>\ROOT\Key\SubKey'
+    *   4) '0x<vaCMHIVE>\ORPHAN\Key\SubKey'          (orphan key)
+    * -- hVMM
+    * -- uszFullPathKey
+    * -- dwIndex = sub-key index 0..N (-1 for key).
+    * -- lpName
+    * -- lpcchName
+    * -- lpftLastWriteTime
+    * -- return
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_WinReg_EnumKeyExU(
+            _In_ VMM_HANDLE hVMM,
+            _In_ LPSTR uszFullPathKey,
+            _In_ DWORD dwIndex,
+            _Out_writes_opt_(*lpcchName) LPSTR lpName,
+            _Inout_ LPDWORD lpcchName,
+            _Out_opt_ PFILETIME lpftLastWriteTime
+        );
 
-/*
-* Enumerate registry values given a registry key - similar to WINAPI function
-* 'EnumValueW'. Please consult WINAPI function documentation for information.
-* May be called in two ways:
-* May be called with HKLM base or virtual address of CMHIVE base examples:
-*   1) 'HKLM\SOFTWARE\Key\SubKey'
-*   2) 'HKLM\ORPHAN\SAM\Key\SubKey'              (orphan key)
-*   3) '0x<vaCMHIVE>\ROOT\Key\SubKey'
-*   4) '0x<vaCMHIVE>\ORPHAN\Key\SubKey'          (orphan key)
-* -- wszFullPathKey
-* -- dwIndex
-* -- lpValueName
-* -- lpcchValueName
-* -- lpType
-* -- lpData
-* -- lpcbData
-* -- return
-*/
-_Success_(return)
-BOOL VMMDLL_WinReg_EnumValueW(
-    _In_ LPWSTR wszFullPathKey,
-    _In_ DWORD dwIndex,
-    _Out_writes_opt_(*lpcchValueName) LPWSTR lpValueName,
-    _Inout_ LPDWORD lpcchValueName,
-    _Out_opt_ LPDWORD lpType,
-    _Out_writes_opt_(*lpcbData) LPBYTE lpData,
-    _Inout_opt_ LPDWORD lpcbData
-);
+    /*
+    * Enumerate registry values given a registry key - similar to WINAPI function
+    * 'EnumValueW'. Please consult WINAPI function documentation for information.
+    * May be called in two ways:
+    * May be called with HKLM base or virtual address of CMHIVE base examples:
+    *   1) 'HKLM\SOFTWARE\Key\SubKey'
+    *   2) 'HKLM\ORPHAN\SAM\Key\SubKey'              (orphan key)
+    *   3) '0x<vaCMHIVE>\ROOT\Key\SubKey'
+    *   4) '0x<vaCMHIVE>\ORPHAN\Key\SubKey'          (orphan key)
+    * -- hVMM
+    * -- uszFullPathKey
+    * -- dwIndex
+    * -- lpValueName
+    * -- lpcchValueName
+    * -- lpType
+    * -- lpData
+    * -- lpcbData
+    * -- return
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_WinReg_EnumValueU(
+            _In_ VMM_HANDLE hVMM,
+            _In_ LPSTR uszFullPathKey,
+            _In_ DWORD dwIndex,
+            _Out_writes_opt_(*lpcchValueName) LPSTR lpValueName,
+            _Inout_ LPDWORD lpcchValueName,
+            _Out_opt_ LPDWORD lpType,
+            _Out_writes_opt_(*lpcbData) LPBYTE lpData,
+            _Inout_opt_ LPDWORD lpcbData
+        );
 
-/*
-* Query a registry value given a registry key/value path - similar to WINAPI
-* function 'RegQueryValueEx'.
-* Please consult WINAPI function documentation for information.
-* May be called with HKLM base or virtual address of CMHIVE base examples:
-*   1) 'HKLM\SOFTWARE\Key\SubKey\Value'
-*   2) 'HKLM\ORPHAN\SAM\Key\SubKey\'             (orphan key and default value)
-*   3) '0x<vaCMHIVE>\ROOT\Key\SubKey\Value'
-*   4) '0x<vaCMHIVE>\ORPHAN\Key\SubKey\Value'    (orphan key value)
-* -- wszFullPathKeyValue
-* -- lpType
-* -- lpData
-* -- lpcbData
-* -- return
-*/
-_Success_(return)
-BOOL VMMDLL_WinReg_QueryValueExW(
-    _In_ LPWSTR wszFullPathKeyValue,
-    _Out_opt_ LPDWORD lpType,
-    _Out_writes_opt_(*lpcbData) LPBYTE lpData,
-    _When_(lpData == NULL, _Out_opt_) _When_(lpData != NULL, _Inout_opt_) LPDWORD lpcbData
-);
+    /*
+    * Query a registry value given a registry key/value path - similar to WINAPI
+    * function 'RegQueryValueEx'.
+    * Please consult WINAPI function documentation for information.
+    * May be called with HKLM base or virtual address of CMHIVE base examples:
+    *   1) 'HKLM\SOFTWARE\Key\SubKey\Value'
+    *   2) 'HKLM\ORPHAN\SAM\Key\SubKey\'             (orphan key and default value)
+    *   3) '0x<vaCMHIVE>\ROOT\Key\SubKey\Value'
+    *   4) '0x<vaCMHIVE>\ORPHAN\Key\SubKey\Value'    (orphan key value)
+    * -- hVMM
+    * -- uszFullPathKeyValue
+    * -- lpType
+    * -- lpData
+    * -- lpcbData
+    * -- return
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_WinReg_QueryValueExU(
+            _In_ VMM_HANDLE hVMM,
+            _In_ LPSTR uszFullPathKeyValue,
+            _Out_opt_ LPDWORD lpType,
+            _Out_writes_opt_(*lpcbData) LPBYTE lpData,
+            _When_(lpData == NULL, _Out_opt_) _When_(lpData != NULL, _Inout_opt_) LPDWORD lpcbData
+        );
+
+    /*
+    * Enumerate registry sub keys - similar to WINAPI function 'RegEnumKeyExW.'
+    * Please consult WINAPI function documentation for information.
+    * May be called with HKLM base or virtual address of CMHIVE base examples:
+    *   1) 'HKLM\SOFTWARE\Key\SubKey'
+    *   2) 'HKLM\ORPHAN\SAM\Key\SubKey'              (orphan key)
+    *   3) '0x<vaCMHIVE>\ROOT\Key\SubKey'
+    *   4) '0x<vaCMHIVE>\ORPHAN\Key\SubKey'          (orphan key)
+    * -- hVMM
+    * -- wszFullPathKey
+    * -- dwIndex = sub-key index 0..N (-1 for key).
+    * -- lpName
+    * -- lpcchName
+    * -- lpftLastWriteTime
+    * -- return
+    */
+    _Success_(return)
+        BOOL VMMDLL_WinReg_EnumKeyExW(
+            _In_ VMM_HANDLE hVMM,
+            _In_ LPWSTR wszFullPathKey,
+            _In_ DWORD dwIndex,
+            _Out_writes_opt_(*lpcchName) LPWSTR lpName,
+            _Inout_ LPDWORD lpcchName,
+            _Out_opt_ PFILETIME lpftLastWriteTime
+        );
+
+    /*
+    * Enumerate registry values given a registry key - similar to WINAPI function
+    * 'EnumValueW'. Please consult WINAPI function documentation for information.
+    * May be called in two ways:
+    * May be called with HKLM base or virtual address of CMHIVE base examples:
+    *   1) 'HKLM\SOFTWARE\Key\SubKey'
+    *   2) 'HKLM\ORPHAN\SAM\Key\SubKey'              (orphan key)
+    *   3) '0x<vaCMHIVE>\ROOT\Key\SubKey'
+    *   4) '0x<vaCMHIVE>\ORPHAN\Key\SubKey'          (orphan key)
+    * -- hVMM
+    * -- wszFullPathKey
+    * -- dwIndex
+    * -- lpValueName
+    * -- lpcchValueName
+    * -- lpType
+    * -- lpData
+    * -- lpcbData
+    * -- return
+    */
+    _Success_(return)
+        BOOL VMMDLL_WinReg_EnumValueW(
+            _In_ VMM_HANDLE hVMM,
+            _In_ LPWSTR wszFullPathKey,
+            _In_ DWORD dwIndex,
+            _Out_writes_opt_(*lpcchValueName) LPWSTR lpValueName,
+            _Inout_ LPDWORD lpcchValueName,
+            _Out_opt_ LPDWORD lpType,
+            _Out_writes_opt_(*lpcbData) LPBYTE lpData,
+            _Inout_opt_ LPDWORD lpcbData
+        );
+
+    /*
+    * Query a registry value given a registry key/value path - similar to WINAPI
+    * function 'RegQueryValueEx'.
+    * Please consult WINAPI function documentation for information.
+    * May be called with HKLM base or virtual address of CMHIVE base examples:
+    *   1) 'HKLM\SOFTWARE\Key\SubKey\Value'
+    *   2) 'HKLM\ORPHAN\SAM\Key\SubKey\'             (orphan key and default value)
+    *   3) '0x<vaCMHIVE>\ROOT\Key\SubKey\Value'
+    *   4) '0x<vaCMHIVE>\ORPHAN\Key\SubKey\Value'    (orphan key value)
+    * -- hVMM
+    * -- wszFullPathKeyValue
+    * -- lpType
+    * -- lpData
+    * -- lpcbData
+    * -- return
+    */
+    _Success_(return)
+        BOOL VMMDLL_WinReg_QueryValueExW(
+            _In_ VMM_HANDLE hVMM,
+            _In_ LPWSTR wszFullPathKeyValue,
+            _Out_opt_ LPDWORD lpType,
+            _Out_writes_opt_(*lpcbData) LPBYTE lpData,
+            _When_(lpData == NULL, _Out_opt_) _When_(lpData != NULL, _Inout_opt_) LPDWORD lpcbData
+        );
 
 
 
-//-----------------------------------------------------------------------------
-// WINDOWS SPECIFIC NETWORKING FUNCTIONALITY BELOW:
-//-----------------------------------------------------------------------------
+    //-----------------------------------------------------------------------------
+    // WINDOWS SPECIFIC UTILITY FUNCTIONS BELOW:
+    //-----------------------------------------------------------------------------
 
-#define VMMDLL_WIN_TCPIP_MAGIC        0xc0ffee663df93685
-#define VMMDLL_WIN_TCPIP_VERSION      1
-
-typedef struct tdVMMDLL_WIN_TCPIP_ENTRY {   // SHARED WITH VMMWINTCPIP
-    DWORD dwPID;
-    DWORD dwState;
-    CHAR szState[12];
-    struct {    // address family (IPv4/IPv6)
+    typedef struct tdVMMDLL_WIN_THUNKINFO_IAT {
         BOOL fValid;
-        WORD wAF;
-    } AF;
-    struct {
-        BOOL fValid;
-        WORD wPort;
-        BYTE pbA[16];   // ipv4 = 1st 4 bytes, ipv6 = all bytes
-    } Src;
-    struct {
-        BOOL fValid;
-        WORD wPort;
-        BYTE pbA[16];   // ipv4 = 1st 4 bytes, ipv6 = all bytes
-    } Dst;
-    QWORD vaTcpE;
-    QWORD qwTime;
-    QWORD vaEPROCESS;
-    QWORD _Reserved[2];
-} VMMDLL_WIN_TCPIP_ENTRY, *PVMMDLL_WIN_TCPIP_ENTRY;
+        BOOL f32;               // if TRUE fn is a 32-bit/4-byte entry, otherwise 64-bit/8-byte entry.
+        ULONG64 vaThunk;        // address of import address table 'thunk'.
+        ULONG64 vaFunction;     // value if import address table 'thunk' == address of imported function.
+        ULONG64 vaNameModule;   // address of name string for imported module.
+        ULONG64 vaNameFunction; // address of name string for imported function.
+    } VMMDLL_WIN_THUNKINFO_IAT, * PVMMDLL_WIN_THUNKINFO_IAT;
 
-typedef struct tdVMMDLL_WIN_TCPIP {
-    QWORD magic;
-    DWORD dwVersion;
-    DWORD cTcpE;
-    VMMDLL_WIN_TCPIP_ENTRY pTcpE[];
-} VMMDLL_WIN_TCPIP, *PVMMDLL_WIN_TCPIP;
-
-/*
-* Retrieve networking information about network connections related to Windows TCP/IP stack.
-* NB! CALLER IS RESPONSIBLE FOR VMMDLL_MemFree return value!
-* CALLER FREE: VMMDLL_MemFree(return)
-* -- return - fail: NULL, success: a PVMMDLL_WIN_TCPIP struct scontaining the result - NB! Caller responsible for VMMDLL_MemFree!
-*/
-PVMMDLL_WIN_TCPIP VMMDLL_WinNet_Get();
+    /*
+    * Retrieve information about the import address table IAT thunk for an imported
+    * function. This includes the virtual address of the IAT thunk which is useful
+    * for hooking.
+    * -- hVMM
+    * -- dwPID
+    * -- [uw]szModuleName
+    * -- szImportModuleName
+    * -- szImportFunctionName
+    * -- pThunkIAT
+    * -- return
+    */
+    EXPORTED_FUNCTION
+        _Success_(return) BOOL VMMDLL_WinGetThunkInfoIATU(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_ LPSTR  uszModuleName, _In_ LPSTR szImportModuleName, _In_ LPSTR szImportFunctionName, _Out_ PVMMDLL_WIN_THUNKINFO_IAT pThunkInfoIAT);
+    _Success_(return) BOOL VMMDLL_WinGetThunkInfoIATW(_In_ VMM_HANDLE hVMM, _In_ DWORD dwPID, _In_ LPWSTR wszModuleName, _In_ LPSTR szImportModuleName, _In_ LPSTR szImportFunctionName, _Out_ PVMMDLL_WIN_THUNKINFO_IAT pThunkInfoIAT);
 
 
 
-//-----------------------------------------------------------------------------
-// WINDOWS SPECIFIC UTILITY FUNCTIONS BELOW:
-//-----------------------------------------------------------------------------
+    //-----------------------------------------------------------------------------
+    // VMM VM FUNCTIONALITY BELOW:
+    //-----------------------------------------------------------------------------
 
-typedef struct tdVMMDLL_WIN_THUNKINFO_IAT {
-    BOOL fValid;
-    BOOL f32;               // if TRUE fn is a 32-bit/4-byte entry, otherwise 64-bit/8-byte entry.
-    ULONG64 vaThunk;        // address of import address table 'thunk'.
-    ULONG64 vaFunction;     // value if import address table 'thunk' == address of imported function.
-    ULONG64 vaNameModule;   // address of name string for imported module.
-    ULONG64 vaNameFunction; // address of name string for imported function.
-} VMMDLL_WIN_THUNKINFO_IAT, *PVMMDLL_WIN_THUNKINFO_IAT;
+    /*
+    * Retrieve a VMM handle given a VM handle.
+    * This is not allowed on physical memory only VMs.
+    * This VMM handle should be closed by calling VMMDLL_Close().
+    * -- hVMM
+    * -- hVM
+    * -- return
+    */
+    EXPORTED_FUNCTION _Success_(return != NULL)
+        VMM_HANDLE VMMDLL_VmGetVmmHandle(_In_ VMM_HANDLE hVMM, _In_ VMMVM_HANDLE hVM);
 
-typedef struct tdVMMDLL_WIN_THUNKINFO_EAT {
-    BOOL fValid;
-    DWORD valueThunk;       // value of export address table 'thunk'.
-    ULONG64 vaThunk;        // address of import address table 'thunk'.
-    ULONG64 vaNameFunction; // address of name string for exported function.
-    ULONG64 vaFunction;     // address of exported function (module base + value parameter).
-} VMMDLL_WIN_THUNKINFO_EAT, *PVMMDLL_WIN_THUNKINFO_EAT;
+    /*
+    * Initialize a scatter handle which is used to efficiently read/write memory in
+    * virtual machines (VMs).
+    * CALLER CLOSE: VMMDLL_Scatter_CloseHandle(return)
+    * -- hVMM
+    * -- hVM = virtual machine handle; acquired from VMMDLL_Map_GetVM*)
+    * -- flags = optional flags as given by VMMDLL_FLAG_*
+    * -- return = handle to be used in VMMDLL_Scatter_* functions.
+    */
+    EXPORTED_FUNCTION _Success_(return != NULL)
+        VMMDLL_SCATTER_HANDLE VMMDLL_VmScatterInitialize(_In_ VMM_HANDLE hVMM, _In_ VMMVM_HANDLE hVM);
 
-/*
-* Retrieve information about the import address table IAT thunk for an imported
-* function. This includes the virtual address of the IAT thunk which is useful
-* for hooking.
-* -- dwPID
-* -- wszModuleName
-* -- szImportModuleName
-* -- szImportFunctionName
-* -- pThunkIAT
-* -- return
-*/
-_Success_(return)
-BOOL VMMDLL_WinGetThunkInfoIAT(_In_ DWORD dwPID, _In_ LPWSTR wszModuleName, _In_ LPSTR szImportModuleName, _In_ LPSTR szImportFunctionName, _Out_ PVMMDLL_WIN_THUNKINFO_IAT pThunkInfoIAT);
+    /*
+    * Read virtual machine (VM) guest physical address (GPA) memory.
+    * -- hVMM
+    * -- hVM = virtual machine handle.
+    * -- qwGPA
+    * -- pb
+    * -- cb
+    * -- return = success/fail (depending if all requested bytes are read or not).
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_VmMemRead(_In_ VMM_HANDLE hVMM, _In_ VMMVM_HANDLE hVM, _In_ ULONG64 qwGPA, _Out_writes_(cb) PBYTE pb, _In_ DWORD cb);
 
-/*
-* Retrieve information about the export address table EAT thunk for an exported
-* function. This includes the virtual address of the EAT thunk which is useful
-* for hooking.
-* -- dwPID
-* -- wszModuleName
-* -- pThunkEAT
-* -- return
-*/
-_Success_(return)
-BOOL VMMDLL_WinGetThunkInfoEAT(_In_ DWORD dwPID, _In_ LPWSTR wszModuleName, _In_ LPSTR szExportFunctionName, _Out_ PVMMDLL_WIN_THUNKINFO_EAT pThunkInfoEAT);
+    /*
+    * Write virtual machine (VM) guest physical address (GPA) memory.
+    * -- hVMM
+    * -- hVM = virtual machine handle.
+    * -- qwGPA
+    * -- pb
+    * -- cb
+    * -- return = TRUE on success, FALSE on partial or zero write.
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_VmMemWrite(_In_ VMM_HANDLE hVMM, _In_ VMMVM_HANDLE hVM, _In_ ULONG64 qwGPA, _In_reads_(cb) PBYTE pb, _In_ DWORD cb);
+
+    /*
+    * Scatter read virtual machine (VM) guest physical address (GPA) memory.
+    * Non contiguous 4096-byte pages. Not cached.
+    * -- hVmm
+    * -- hVM = virtual machine handle.
+    * -- ppMEMsGPA
+    * -- cpMEMsGPA
+    * -- flags = (reserved future use).
+    * -- return = the number of successfully read items.
+    */
+    EXPORTED_FUNCTION
+        DWORD VMMDLL_VmMemReadScatter(_In_ VMM_HANDLE hVMM, _In_ VMMVM_HANDLE hVM, _Inout_ PPMEM_SCATTER ppMEMsGPA, _In_ DWORD cpMEMsGPA, _In_ DWORD flags);
+
+    /*
+    * Scatter write virtual machine (VM) guest physical address (GPA) memory.
+    * Non contiguous 4096-byte pages. Not cached.
+    * -- hVmm
+    * -- hVM = virtual machine handle.
+    * -- ppMEMsGPA
+    * -- cpMEMsGPA
+    * -- return = the number of hopefully successfully written items.
+    */
+    EXPORTED_FUNCTION
+        DWORD VMMDLL_VmMemWriteScatter(_In_ VMM_HANDLE hVMM, _In_ VMMVM_HANDLE hVM, _Inout_ PPMEM_SCATTER ppMEMsGPA, _In_ DWORD cpMEMsGPA);
+
+    /*
+    * Translate a virtual machine (VM) guest physical address (GPA) to:
+    * (1) Physical Address (PA) _OR_ (2) Virtual Address (VA) in 'vmmem' process.
+    * -- hVMM
+    * -- HVM
+    * -- qwGPA = guest physical address to translate.
+    * -- pPA = translated physical address (if exists).
+    * -- pVA = translated virtual address inside 'vmmem' process (if exists).
+    * -- return = success/fail.
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_VmMemTranslateGPA(_In_ VMM_HANDLE H, _In_ VMMVM_HANDLE hVM, _In_ ULONG64 qwGPA, _Out_opt_ PULONG64 pPA, _Out_opt_ PULONG64 pVA);
 
 
 
-//-----------------------------------------------------------------------------
-// VMM UTIL FUNCTIONALITY BELOW:
-//-----------------------------------------------------------------------------
+    //-----------------------------------------------------------------------------
+    // VMM UTIL FUNCTIONALITY BELOW:
+    //-----------------------------------------------------------------------------
 
-/*
-* Fill a human readable hex ascii memory dump into the caller supplied sz buffer.
-* -- pb
-* -- cb
-* -- cbInitialOffset = offset, must be max 0x1000 and multiple of 0x10.
-* -- sz = buffer to fill, NULL to retrieve buffer size in pcsz parameter.
-* -- pcsz = IF sz==NULL :: size of buffer (including space for terminating NULL) on exit
-*           IF sz!=NULL :: size of buffer on entry, size of characters (excluding terminating NULL) on exit.
-*/
-_Success_(return)
-BOOL VMMDLL_UtilFillHexAscii(_In_ PBYTE pb, _In_ DWORD cb, _In_ DWORD cbInitialOffset, _Out_opt_ LPSTR sz, _Inout_ PDWORD pcsz);
+    /*
+    * Fill a human readable hex ascii memory dump into the caller supplied sz buffer.
+    * -- pb
+    * -- cb
+    * -- cbInitialOffset = offset, must be max 0x1000 and multiple of 0x10.
+    * -- sz = buffer to fill, NULL to retrieve buffer size in pcsz parameter.
+    * -- pcsz = IF sz==NULL :: size of buffer (including space for terminating NULL) on exit
+    *           IF sz!=NULL :: size of buffer on entry, size of characters (excluding terminating NULL) on exit.
+    */
+    EXPORTED_FUNCTION _Success_(return)
+        BOOL VMMDLL_UtilFillHexAscii(
+            _In_reads_opt_(cb) PBYTE pb,
+            _In_ DWORD cb,
+            _In_ DWORD cbInitialOffset,
+            _Out_writes_opt_(*pcsz) LPSTR sz,
+            _Inout_ PDWORD pcsz
+        );
 
 
+
+    //-----------------------------------------------------------------------------
+    // DEFAULT (WINDOWS ONLY) COMPATIBILITY FUNCTION DEFINITIONS BELOW:
+    //-----------------------------------------------------------------------------
+
+#ifdef _WIN32
+#define VMMDLL_VfsList                  VMMDLL_VfsListW
+#define VMMDLL_VfsRead                  VMMDLL_VfsReadW
+#define VMMDLL_VfsWrite                 VMMDLL_VfsWriteW
+#define VMMDLL_ProcessGetDirectories    VMMDLL_ProcessGetDirectoriesW
+#define VMMDLL_ProcessGetSections       VMMDLL_ProcessGetSectionsW
+#define VMMDLL_ProcessGetProcAddress    VMMDLL_ProcessGetProcAddressW
+#define VMMDLL_ProcessGetModuleBase     VMMDLL_ProcessGetModuleBaseW
+#define VMMDLL_Map_GetPte               VMMDLL_Map_GetPteW
+#define VMMDLL_Map_GetVad               VMMDLL_Map_GetVadW
+#define VMMDLL_Map_GetModule            VMMDLL_Map_GetModuleW
+#define VMMDLL_Map_GetModuleFromName    VMMDLL_Map_GetModuleFromNameW
+#define VMMDLL_Map_GetUnloadedModule    VMMDLL_Map_GetUnloadedModuleW
+#define VMMDLL_Map_GetEAT               VMMDLL_Map_GetEATW
+#define VMMDLL_Map_GetIAT               VMMDLL_Map_GetIATW
+#define VMMDLL_Map_GetHandle            VMMDLL_Map_GetHandleW
+#define VMMDLL_Map_GetNet               VMMDLL_Map_GetNetW
+#define VMMDLL_Map_GetUsers             VMMDLL_Map_GetUsersW
+#define VMMDLL_Map_GetServices          VMMDLL_Map_GetServicesW
+#define VMMDLL_WinGetThunkInfoIAT       VMMDLL_WinGetThunkInfoIATW
+#endif /* _WIN32 */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
I fixed a issue where you had
`if (!DMA_INITIALIZED || PROCESS_INITIALIZED)` 
which should've been 
`if (!DMA_INITIALIZED || !PROCESS_INITIALIZED)`

I've added a option to make use of memory map, which it now also automatically dumps.

Changed VMM to the latest version which has Handles when initializing VMM, because i was having issues when closing the VMM and then re-opening it again on the version without any handles.

Added basic examples for using the scatter reads & writes.

Also now properly closing the memory should someone forget to use closeDMA (:

Please let me know if there are any changes you dislike so I can change them :)